### PR TITLE
Fix Code of Conduct URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Code of Conduct
 
-Everyone interacting in the Stytch project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/stytch/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the Stytch project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/stytchauth/stytch-ruby/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
The "Code of Conduct" link 404s because of the `[USERNAME]` placeholder in the URL.  This PR corrects the URL so it points to the Code of Conduct included in the repo.
