### PR TITLE
Add Stytch and IdP sessions at the same time

### DIFF
--- a/lib/stytch/oauth.rb
+++ b/lib/stytch/oauth.rb
@@ -14,7 +14,6 @@ module Stytch
 
     def authenticate(
       token:,
-      session_management_type: nil,
       session_token: nil,
       session_jwt: nil,
       session_duration_minutes: nil
@@ -22,7 +21,6 @@ module Stytch
       request = {
         token: token
       }
-      request[:session_management_type] = session_management_type unless session_management_type.nil?
       request[:session_token] = session_token unless session_token.nil?
       request[:session_jwt] = session_jwt unless session_jwt.nil?
       request[:session_duration_minutes] = session_duration_minutes unless session_duration_minutes.nil?

--- a/lib/stytch/version.rb
+++ b/lib/stytch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stytch
-  VERSION = '2.12.0'
+  VERSION = '3.0.0'
 end


### PR DESCRIPTION
The API now supports using Stytch and IdP sessions at the same time for [the OAuthAuthenticate endpoint](https://stytch.com/docs/api/oauth-authenticate). Users no longer need to specify a `session_management_type` as IdP sessions are always returned now and a Stytch session will be returned if a `session_duration_minutes` is specified.

This is considered a breaking change because we are removing the `session_management_type` field from the input and changing the response to follow the pattern of other authenticate methods.