### PR TITLE
feat: Add user search methods

### DIFF
--- a/lib/stytch/users.rb
+++ b/lib/stytch/users.rb
@@ -12,6 +12,30 @@ module Stytch
       @connection = connection
     end
 
+    def search(query, limit: 100, cursor: nil)
+      request = {
+        query: query,
+        limit: limit
+      }
+      request[:cursor] = cursor if cursor
+      post_request("#{PATH}/search", request)
+    end
+
+    def search_all(query, limit: 100)
+      Enumerator.new do |enum|
+        cursor = nil
+        loop do
+          resp = search(query, limit: limit, cursor: cursor)
+          resp['results'].each do |user|
+            enum << user
+          end
+
+          cursor = resp['results_metadata']['next_cursor']
+          break if cursor.nil?
+        end
+      end
+    end
+
     def get(user_id:)
       get_request("#{PATH}/#{user_id}")
     end

--- a/lib/stytch/version.rb
+++ b/lib/stytch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stytch
-  VERSION = '3.0.0'
+  VERSION = '3.1.0'
 end


### PR DESCRIPTION
This adds support for the `/users/search` endpoint, including a helper
method that uses the search cursor to build an Enumerator for the full
query results.

Here's an example of usage:
```ruby
query = {
  operator: 'AND',
  operands: [
    { filter_name: 'email_address_fuzzy', filter_value: 'hopper' },
    { filter_name: 'status', filter_value: 'active' }
  ]
}

client.users.search_all(query, limit: 10).find_all do |user|
  puts user['name']
end
```
