### PR TITLE
fix: Extract the session ID from the session claim

### DIFF
--- a/lib/stytch/sessions.rb
+++ b/lib/stytch/sessions.rb
@@ -114,7 +114,7 @@ module Stytch
     def marshal_jwt_into_session(jwt)
       stytch_claim = "https://stytch.com/session"
       return {
-        "session_id" => jwt["jti"],
+        "session_id" => jwt[stytch_claim]["id"],
         "user_id" => jwt["sub"],
         "started_at" => jwt[stytch_claim]["started_at"],
         "last_accessed_at" => jwt[stytch_claim]["last_accessed_at"],

--- a/lib/stytch/version.rb
+++ b/lib/stytch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stytch
-  VERSION = '3.1.0'
+  VERSION = '3.1.1'
 end


### PR DESCRIPTION
In session JWTs, the session claim is the more reliable source of the session ID. The "jti" claim
happens to also contain that now, but it will not in the future.
