### PR TITLE
feat: Allow custom env values for internal dev URLs

### DIFF
--- a/lib/stytch/client.rb
+++ b/lib/stytch/client.rb
@@ -36,15 +36,15 @@ module Stytch
 
     def api_host(env)
       case env
-      when :live, 'live'
+      when :live
         'https://api.stytch.com'
-      when :test, 'test'
+      when :test
         'https://test.stytch.com'
-      when String
-        # Assume this is an internal development URL
+      when /\Ahttps?:\/\//
+        # If this is a string that looks like a URL, assume it's an internal development URL.
         env
       else
-        raise ArgumentError, "Invalid value for env (#{@env}): should be live or test"
+        raise ArgumentError, "Invalid value for env (#{env}): should be :live or :test"
       end
     end
 

--- a/lib/stytch/client.rb
+++ b/lib/stytch/client.rb
@@ -36,10 +36,13 @@ module Stytch
 
     def api_host(env)
       case env
-      when :live
+      when :live, 'live'
         'https://api.stytch.com'
-      when :test
+      when :test, 'test'
         'https://test.stytch.com'
+      when String
+        # Assume this is an internal development URL
+        env
       else
         raise ArgumentError, "Invalid value for env (#{@env}): should be live or test"
       end

--- a/lib/stytch/version.rb
+++ b/lib/stytch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stytch
-  VERSION = '3.2.1'
+  VERSION = '3.3.0'
 end

--- a/lib/stytch/version.rb
+++ b/lib/stytch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stytch
-  VERSION = '3.3.0'
+  VERSION = '3.4.0'
 end

--- a/spec/stytch/client_spec.rb
+++ b/spec/stytch/client_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'faraday'
+require 'faraday_middleware'
+
+require_relative '../../lib/stytch/client'
+require_relative '../../lib/stytch/middleware'
+
+require 'test/unit'
+
+class TestClient < Test::Unit::TestCase
+  def test_production_environments
+    _client = Stytch::Client.new(
+      env: :test,
+      project_id: 'project-test-00000000-0000-0000-0000-000000000000',
+      secret: 'secret-test-11111111-1111-1111-1111-111111111111',
+    )
+
+    _client = Stytch::Client.new(
+      env: :live,
+      project_id: 'project-live-00000000-0000-0000-0000-000000000000',
+      secret: 'secret-live-11111111-1111-1111-1111-111111111111',
+    )
+  end
+
+  def test_development_url
+    _client = Stytch::Client.new(
+      env: 'http://localhost:8000',
+      project_id: 'project-test-00000000-0000-0000-0000-000000000000',
+      secret: 'secret-test-11111111-1111-1111-1111-111111111111',
+    )
+  end
+end

--- a/spec/stytch/client_spec.rb
+++ b/spec/stytch/client_spec.rb
@@ -23,11 +23,27 @@ class TestClient < Test::Unit::TestCase
     )
   end
 
-  def test_development_url
+  def test_development_urls
     _client = Stytch::Client.new(
       env: 'http://localhost:8000',
       project_id: 'project-test-00000000-0000-0000-0000-000000000000',
       secret: 'secret-test-11111111-1111-1111-1111-111111111111',
     )
+
+    _client = Stytch::Client.new(
+      env: 'https://foo.stytch.test',
+      project_id: 'project-test-00000000-0000-0000-0000-000000000000',
+      secret: 'secret-test-11111111-1111-1111-1111-111111111111',
+    )
+  end
+
+  def test_invalid_env
+    assert_raises(ArgumentError) do
+      _client = Stytch::Client.new(
+        env: 'ftp://url',
+        project_id: 'project-test-00000000-0000-0000-0000-000000000000',
+        secret: 'secret-test-11111111-1111-1111-1111-111111111111',
+      )
+    end
   end
 end


### PR DESCRIPTION
API client setup uses the `env` value to set the correct base URI for that environment. This is
great for the production live and test environments (which are the only supported ones!), but that
makes it difficult to use this within a Stytch development environment as a Stytch API developer.

So this relaxes the error on the `env` value. If it's one of the two recognized environments,
derive the URL from it. If it's not, but it looks like a URL, treat it as a base URL to use when
building requests.