### PR TITLE
fix: Remove trailing commas in method definitions

### DIFF
--- a/lib/stytch/crypto_wallets.rb
+++ b/lib/stytch/crypto_wallets.rb
@@ -17,7 +17,7 @@ module Stytch
       crypto_wallet_type:,
       user_id: nil,
       session_token: nil,
-      session_jwt: nil,
+      session_jwt: nil
     )
       request = {
         crypto_wallet_address: crypto_wallet_address,

--- a/lib/stytch/magic_links.rb
+++ b/lib/stytch/magic_links.rb
@@ -75,7 +75,7 @@ module Stytch
         code_challenge: nil,
         user_id: nil,
         session_token: nil,
-        session_jwt: nil,
+        session_jwt: nil
       )
         request = {
           email: email

--- a/lib/stytch/otps.rb
+++ b/lib/stytch/otps.rb
@@ -58,7 +58,7 @@ module Stytch
         attributes: {},
         user_id: nil,
         session_token: nil,
-        session_jwt: nil,
+        session_jwt: nil
       )
         request = {
           phone_number: phone_number,
@@ -106,7 +106,7 @@ module Stytch
         attributes: {},
         user_id: nil,
         session_token: nil,
-        session_jwt: nil,
+        session_jwt: nil
       )
         request = {
           phone_number: phone_number,
@@ -154,7 +154,7 @@ module Stytch
         attributes: {},
         user_id: nil,
         session_token: nil,
-        session_jwt: nil,
+        session_jwt: nil
       )
         request = {
           email: email,

--- a/lib/stytch/version.rb
+++ b/lib/stytch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stytch
-  VERSION = '3.13.0'
+  VERSION = '3.13.1'
 end


### PR DESCRIPTION
This causes a syntax error on `require`, preventing anyone from using the library.

Closes #64