### PR TITLE
ci: Add test matrix for all supported Ruby versions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,39 @@
+name: Ruby
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          # Start at the minimum required Ruby version in the gemspec.
+          - '2.3'
+          - '2.4'
+          - '2.5'
+          - '2.6'
+          - '2.7'
+          - '3.0'
+          - '3.1'
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+
+          # The default RubyGems version for older Rubies has a bug that prevents
+          # `required_ruby_version` from working for Bundler. This was fixed in v3.2.3.
+          #
+          # The setup-ruby action will still use the default RubyGems if that version is newer
+          # than the one we specify here.
+          rubygems: '3.2.3'
+          bundler-cache: true
+
+      - run: bundle exec rspec

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,10 +13,6 @@ jobs:
       matrix:
         ruby:
           # Start at the minimum required Ruby version in the gemspec.
-          - '2.3'
-          - '2.4'
-          - '2.5'
-          - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'
@@ -27,13 +23,6 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-
-          # The default RubyGems version for older Rubies has a bug that prevents
-          # `required_ruby_version` from working for Bundler. This was fixed in v3.2.3.
-          #
-          # The setup-ruby action will still use the default RubyGems if that version is newer
-          # than the one we specify here.
-          rubygems: '3.2.3'
           bundler-cache: true
 
       - run: bundle exec rspec

--- a/lib/stytch/version.rb
+++ b/lib/stytch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stytch
-  VERSION = '3.15.0'
+  VERSION = '4.0.0'
 end

--- a/spec/stytch/client_spec.rb
+++ b/spec/stytch/client_spec.rb
@@ -1,21 +1,7 @@
 # frozen_string_literal: true
 
-require 'faraday'
-require 'faraday_middleware'
-
-require_relative '../../lib/stytch/client'
-require_relative '../../lib/stytch/middleware'
-
-require 'test/unit'
-
-class TestClient < Test::Unit::TestCase
-  def test_production_environments
-    _client = Stytch::Client.new(
-      env: :test,
-      project_id: 'project-test-00000000-0000-0000-0000-000000000000',
-      secret: 'secret-test-11111111-1111-1111-1111-111111111111',
-    )
-
+RSpec.describe Stytch::Client do
+  it 'accepts production config' do
     _client = Stytch::Client.new(
       env: :live,
       project_id: 'project-live-00000000-0000-0000-0000-000000000000',
@@ -23,7 +9,15 @@ class TestClient < Test::Unit::TestCase
     )
   end
 
-  def test_development_urls
+  it 'accepts testing config' do
+    _client = Stytch::Client.new(
+      env: :test,
+      project_id: 'project-test-00000000-0000-0000-0000-000000000000',
+      secret: 'secret-test-11111111-1111-1111-1111-111111111111',
+    )
+  end
+
+  it 'accepts development config' do
     _client = Stytch::Client.new(
       env: 'http://localhost:8000',
       project_id: 'project-test-00000000-0000-0000-0000-000000000000',
@@ -37,13 +31,13 @@ class TestClient < Test::Unit::TestCase
     )
   end
 
-  def test_invalid_env
-    assert_raises(ArgumentError) do
+  it 'raises on invalid config' do
+    expect do
       _client = Stytch::Client.new(
         env: 'ftp://url',
         project_id: 'project-test-00000000-0000-0000-0000-000000000000',
         secret: 'secret-test-11111111-1111-1111-1111-111111111111',
       )
-    end
+    end.to raise_error(ArgumentError)
   end
 end

--- a/stytch.gemspec
+++ b/stytch.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday', '>= 0.17.0', '< 2.0'
   spec.add_dependency 'faraday_middleware', '>= 0.14.0', '< 2.0'
-  spec.add_dependency 'json-jwt', '>=1.13.0'
+  spec.add_dependency 'json-jwt', '>= 1.13.0'
   spec.add_dependency 'jwt', '>= 2.3.0'
 
-  spec.add_development_dependency 'test-unit', '>=3.5.3'
+  spec.add_development_dependency 'rspec', '~> 3.11.0'
 end

--- a/stytch.gemspec
+++ b/stytch.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'Stytch Ruby Gem'
   spec.homepage      = 'https://stytch.com'
   spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.3.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.7.0')
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/stytchauth/stytch-ruby'


### PR DESCRIPTION
This adds a GitHub workflow to run RSpec on PRs for all supported Ruby versions.

RSpec wasn't running the sessions tests because those were written with `test-unit` instead. So I converted them to RSpec tests and removed the `test-unit` dependency.

# Reviewer Notes

Unusually for this repo, I intend to rebase-merge instead of squash-merge. So please review the individual commits!