### PR TITLE
[SUP-10] Add locale parameter to Email Magic Links, OTP, and Passwords endpoints

### DIFF
--- a/lib/stytch/magic_links.rb
+++ b/lib/stytch/magic_links.rb
@@ -75,7 +75,8 @@ module Stytch
         code_challenge: nil,
         user_id: nil,
         session_token: nil,
-        session_jwt: nil
+        session_jwt: nil,
+        locale: nil
       )
         request = {
           email: email
@@ -90,6 +91,7 @@ module Stytch
         request[:user_id] = user_id unless user_id.nil?
         request[:session_token] = session_token unless session_token.nil?
         request[:session_jwt] = session_jwt unless session_jwt.nil?
+        request[:locale] = locale unless locale.nil?
 
         post_request("#{PATH}/send", request)
       end
@@ -102,7 +104,8 @@ module Stytch
         signup_expiration_minutes: nil,
         attributes: {},
         create_user_as_pending: false,
-        code_challenge: nil
+        code_challenge: nil,
+        locale: nil
       )
         request = {
           email: email,
@@ -115,6 +118,7 @@ module Stytch
         request[:signup_expiration_minutes] = signup_expiration_minutes unless signup_expiration_minutes.nil?
         request[:attributes] = attributes if attributes != {}
         request[:code_challenge] = code_challenge unless code_challenge.nil?
+        request[:locale] = locale unless locale.nil?
 
         post_request("#{PATH}/login_or_create", request)
       end
@@ -124,7 +128,8 @@ module Stytch
         invite_magic_link_url: nil,
         invite_expiration_minutes: nil,
         attributes: {},
-        name: {}
+        name: {},
+        locale: nil
       )
         request = {
           email: email
@@ -134,6 +139,7 @@ module Stytch
         request[:invite_expiration_minutes] = invite_expiration_minutes unless invite_expiration_minutes.nil?
         request[:attributes] = attributes if attributes != {}
         request[:name] = name if name != {}
+        request[:locale] = locale unless locale.nil?
 
         post_request("#{PATH}/invite", request)
       end

--- a/lib/stytch/otps.rb
+++ b/lib/stytch/otps.rb
@@ -154,7 +154,8 @@ module Stytch
         attributes: {},
         user_id: nil,
         session_token: nil,
-        session_jwt: nil
+        session_jwt: nil,
+        locale: nil
       )
         request = {
           email: email,
@@ -165,6 +166,7 @@ module Stytch
         request[:user_id] = user_id unless user_id.nil?
         request[:session_token] = session_token unless session_token.nil?
         request[:session_jwt] = session_jwt unless session_jwt.nil?
+        request[:locale] = locale unless locale.nil?
 
         post_request("#{PATH}/send", request)
       end
@@ -173,7 +175,8 @@ module Stytch
         email:,
         expiration_minutes: nil,
         attributes: {},
-        create_user_as_pending: false
+        create_user_as_pending: false,
+        locale: nil
       )
         request = {
           email: email,
@@ -182,6 +185,7 @@ module Stytch
         }
 
         request[:attributes] = attributes if attributes != {}
+        request[:locale] = locale unless locale.nil?
 
         post_request("#{PATH}/login_or_create", request)
       end

--- a/lib/stytch/otps.rb
+++ b/lib/stytch/otps.rb
@@ -58,7 +58,8 @@ module Stytch
         attributes: {},
         user_id: nil,
         session_token: nil,
-        session_jwt: nil
+        session_jwt: nil,
+        locale: nil
       )
         request = {
           phone_number: phone_number,
@@ -69,6 +70,7 @@ module Stytch
         request[:user_id] = user_id unless user_id.nil?
         request[:session_token] = session_token unless session_token.nil?
         request[:session_jwt] = session_jwt unless session_jwt.nil?
+        request[:locale] = locale unless locale.nil?
 
         post_request("#{PATH}/send", request)
       end
@@ -77,7 +79,8 @@ module Stytch
         phone_number:,
         expiration_minutes: nil,
         attributes: {},
-        create_user_as_pending: false
+        create_user_as_pending: false,
+        locale: nil
       )
         request = {
           phone_number: phone_number,
@@ -86,6 +89,7 @@ module Stytch
         }
 
         request[:attributes] = attributes if attributes != {}
+        request[:locale] = locale unless locale.nil?
 
         post_request("#{PATH}/login_or_create", request)
       end
@@ -106,7 +110,8 @@ module Stytch
         attributes: {},
         user_id: nil,
         session_token: nil,
-        session_jwt: nil
+        session_jwt: nil,
+        locale: nil
       )
         request = {
           phone_number: phone_number,
@@ -117,6 +122,7 @@ module Stytch
         request[:user_id] = user_id unless user_id.nil?
         request[:session_token] = session_token unless session_token.nil?
         request[:session_jwt] = session_jwt unless session_jwt.nil?
+        request[:locale] = locale unless locale.nil?
 
         post_request("#{PATH}/send", request)
       end
@@ -125,7 +131,8 @@ module Stytch
         phone_number:,
         expiration_minutes: nil,
         attributes: {},
-        create_user_as_pending: false
+        create_user_as_pending: false,
+        locale: nil
       )
         request = {
           phone_number: phone_number,
@@ -134,6 +141,7 @@ module Stytch
         }
 
         request[:attributes] = attributes if attributes != {}
+        request[:locale] = locale unless locale.nil?
 
         post_request("#{PATH}/login_or_create", request)
       end

--- a/lib/stytch/passwords.rb
+++ b/lib/stytch/passwords.rb
@@ -107,7 +107,8 @@ module Stytch
         reset_password_redirect_url: nil,
         reset_password_expiration_minutes: nil,
         attributes: {},
-        code_challenge: nil
+        code_challenge: nil,
+        locale: nil
       )
         request = {
           email: email
@@ -121,6 +122,7 @@ module Stytch
         end
         request[:attributes] = attributes if attributes != {}
         request[:code_challenge] = code_challenge unless code_challenge.nil?
+        request[:locale] = locale unless locale.nil?
 
         post_request("#{PATH}/reset/start", request)
       end

--- a/lib/stytch/version.rb
+++ b/lib/stytch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stytch
-  VERSION = '3.14.0'
+  VERSION = '3.15.0'
 end

--- a/lib/stytch/version.rb
+++ b/lib/stytch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stytch
-  VERSION = '3.15.0'
+  VERSION = '3.16.0'
 end


### PR DESCRIPTION
### Description
Adds support for the optional `locale` parameter for the following endpoints:

- /magic_links/email/send
- /magic_links/email/login_or_create
- /magic_links/email/invite
- /otps/email/send
- /otps/email/login_or_create
- /otps/sms/send
- /otps/sms/login_or_create
- /otps/whatsapp/send
- /otps/whatsapp/login_or_create
- /passwords/email/reset/start

The locale parameter specifies the text language of the email that the user receives. Current `locale` options are "en" (English) and "es" (Spanish).
### Dependencies
Support for the `locale` parameter has already been added to Stytch's API endpoints: https://github.com/stytchauth/api/pull/1928