### PR TITLE
feat: Add support for OAuth Attach endpoint

### DIFF
--- a/lib/stytch/oauth.rb
+++ b/lib/stytch/oauth.rb
@@ -31,5 +31,21 @@ module Stytch
 
       post_request("#{PATH}/authenticate", request)
     end
+
+    def attach(
+      provider:,
+      user_id: nil,
+      session_token: nil,
+      session_jwt: nil
+    )
+      request = {
+        provider: provider
+      }
+      request[:user_id] = user_id unless user_id.nil?
+      request[:session_token] = session_token unless session_token.nil?
+      request[:session_jwt] = session_jwt unless session_jwt.nil?
+
+      post_request("#{PATH}/attach", request)
+    end
   end
 end

--- a/lib/stytch/oauth.rb
+++ b/lib/stytch/oauth.rb
@@ -32,6 +32,9 @@ module Stytch
       post_request("#{PATH}/authenticate", request)
     end
 
+    # Send a /v1/oauth/attach request.
+    #
+    # Exactly one of user_id, session_token, or session_jwt is required.
     def attach(
       provider:,
       user_id: nil,

--- a/lib/stytch/version.rb
+++ b/lib/stytch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stytch
-  VERSION = '4.1.0'
+  VERSION = '4.2.0'
 end


### PR DESCRIPTION
This adds support for an upcoming endpoint: OAuth Attach (`/v1/oauth/attach`).
