### PR TITLE
austin/stytch-ruby: update faraday to >= 2.0.1

### DIFF
--- a/lib/stytch.rb
+++ b/lib/stytch.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'faraday'
-require 'faraday_middleware'
 
 require_relative 'stytch/client'
 require_relative 'stytch/middleware'

--- a/lib/stytch/client.rb
+++ b/lib/stytch/client.rb
@@ -54,7 +54,7 @@ module Stytch
       @connection = Faraday.new(url: @api_host) do |builder|
         block_given? ? yield(builder) : build_default_connection(builder)
       end
-      @connection.basic_auth(@project_id, @secret)
+      @connection.set_basic_auth(@project_id, @secret)
     end
 
     def build_default_connection(builder)

--- a/lib/stytch/middleware.rb
+++ b/lib/stytch/middleware.rb
@@ -7,7 +7,7 @@ require 'uri'
 require_relative 'version'
 
 module Stytch
-  class Middleware < ::Faraday::Response::Middleware
+  class Middleware < ::Faraday::Middleware
     NETWORK_HEADERS = {
       'User-Agent' => "Stytch Ruby v#{Stytch::VERSION}",
       'Content-Type' => 'application/json'

--- a/lib/stytch/version.rb
+++ b/lib/stytch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stytch
-  VERSION = '4.3.1'
+  VERSION = '5.0.0'
 end

--- a/stytch.gemspec
+++ b/stytch.gemspec
@@ -25,8 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', '>= 0.17.0', '< 2.0'
-  spec.add_dependency 'faraday_middleware', '>= 0.14.0', '< 2.0'
+  spec.add_dependency 'faraday', '>= 2.0.1', '< 3.0'
   spec.add_dependency 'json-jwt', '>= 1.13.0'
   spec.add_dependency 'jwt', '>= 2.3.0'
 


### PR DESCRIPTION
Updates Faraday to >= 2.0.1 as per #72 

[Faraday Middleware](https://github.com/lostisland/faraday_middleware) was deprecated and partially merged with faraday in faraday 2.0

It is recommended to [skip Faraday 2.0](https://github.com/lostisland/faraday/blob/main/UPGRADING.md)

The upgrade guide references

> Remove Faraday::Response::Middleware. You can now use the new on_complete callback provided by Faraday::Middleware.

so we might need to set something there