### PR TITLE
Decode custom claims in local session auth

### DIFF
--- a/lib/stytch/version.rb
+++ b/lib/stytch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stytch
-  VERSION = '5.0.0'
+  VERSION = '5.0.1'
 end


### PR DESCRIPTION
Adds support for decoding custom claims in local session authentication of JWTs.

## Testing
Got a sample JWT and showed that this method will extract custom claims:
![image](https://github.com/stytchauth/stytch-ruby/assets/119902778/2f79de64-e8e2-43a2-9c05-00822c850275)
