### PR TITLE
Fix StytchB2B::Client (fixes #81)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 
 # rspec failure tracking
 .rspec_status
+
+Gemfile.lock

--- a/lib/stytch/b2b_client.rb
+++ b/lib/stytch/b2b_client.rb
@@ -50,7 +50,7 @@ module StytchB2B
       @connection = Faraday.new(url: @api_host) do |builder|
         block_given? ? yield(builder) : build_default_connection(builder)
       end
-      @connection.basic_auth(@project_id, @secret)
+      @connection.set_basic_auth(@project_id, @secret)
     end
 
     def build_default_connection(builder)

--- a/lib/stytch/version.rb
+++ b/lib/stytch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stytch
-  VERSION = '5.0.1'
+  VERSION = '5.0.2'
 end

--- a/spec/stytch/b2b_client_spec.rb
+++ b/spec/stytch/b2b_client_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe StytchB2B::Client do
+  it 'accepts production config' do
+    _client = StytchB2B::Client.new(
+      env: :live,
+      project_id: 'project-live-00000000-0000-0000-0000-000000000000',
+      secret: 'secret-live-11111111-1111-1111-1111-111111111111',
+    )
+  end
+
+  it 'accepts testing config' do
+    _client = StytchB2B::Client.new(
+      env: :test,
+      project_id: 'project-test-00000000-0000-0000-0000-000000000000',
+      secret: 'secret-test-11111111-1111-1111-1111-111111111111',
+    )
+  end
+
+  it 'accepts development config' do
+    _client = StytchB2B::Client.new(
+      env: 'http://localhost:8000',
+      project_id: 'project-test-00000000-0000-0000-0000-000000000000',
+      secret: 'secret-test-11111111-1111-1111-1111-111111111111',
+    )
+
+    _client = StytchB2B::Client.new(
+      env: 'https://foo.stytch.test',
+      project_id: 'project-test-00000000-0000-0000-0000-000000000000',
+      secret: 'secret-test-11111111-1111-1111-1111-111111111111',
+    )
+  end
+
+  it 'infers environment when not given' do
+    _client = StytchB2B::Client.new(
+      project_id: 'project-test-00000000-0000-0000-0000-000000000000',
+      secret: 'secret-test-11111111-1111-1111-1111-111111111111',
+    )
+  end
+end

--- a/spec/stytch/b2b_client_spec.rb
+++ b/spec/stytch/b2b_client_spec.rb
@@ -1,40 +1,6 @@
 # frozen_string_literal: true
+require_relative "./shared_examples_for_clients"
 
 RSpec.describe StytchB2B::Client do
-  it 'accepts production config' do
-    _client = StytchB2B::Client.new(
-      env: :live,
-      project_id: 'project-live-00000000-0000-0000-0000-000000000000',
-      secret: 'secret-live-11111111-1111-1111-1111-111111111111',
-    )
-  end
-
-  it 'accepts testing config' do
-    _client = StytchB2B::Client.new(
-      env: :test,
-      project_id: 'project-test-00000000-0000-0000-0000-000000000000',
-      secret: 'secret-test-11111111-1111-1111-1111-111111111111',
-    )
-  end
-
-  it 'accepts development config' do
-    _client = StytchB2B::Client.new(
-      env: 'http://localhost:8000',
-      project_id: 'project-test-00000000-0000-0000-0000-000000000000',
-      secret: 'secret-test-11111111-1111-1111-1111-111111111111',
-    )
-
-    _client = StytchB2B::Client.new(
-      env: 'https://foo.stytch.test',
-      project_id: 'project-test-00000000-0000-0000-0000-000000000000',
-      secret: 'secret-test-11111111-1111-1111-1111-111111111111',
-    )
-  end
-
-  it 'infers environment when not given' do
-    _client = StytchB2B::Client.new(
-      project_id: 'project-test-00000000-0000-0000-0000-000000000000',
-      secret: 'secret-test-11111111-1111-1111-1111-111111111111',
-    )
-  end
+  it_behaves_like "a client"
 end

--- a/spec/stytch/client_spec.rb
+++ b/spec/stytch/client_spec.rb
@@ -1,40 +1,6 @@
 # frozen_string_literal: true
+require_relative "./shared_examples_for_clients"
 
 RSpec.describe Stytch::Client do
-  it 'accepts production config' do
-    _client = Stytch::Client.new(
-      env: :live,
-      project_id: 'project-live-00000000-0000-0000-0000-000000000000',
-      secret: 'secret-live-11111111-1111-1111-1111-111111111111',
-    )
-  end
-
-  it 'accepts testing config' do
-    _client = Stytch::Client.new(
-      env: :test,
-      project_id: 'project-test-00000000-0000-0000-0000-000000000000',
-      secret: 'secret-test-11111111-1111-1111-1111-111111111111',
-    )
-  end
-
-  it 'accepts development config' do
-    _client = Stytch::Client.new(
-      env: 'http://localhost:8000',
-      project_id: 'project-test-00000000-0000-0000-0000-000000000000',
-      secret: 'secret-test-11111111-1111-1111-1111-111111111111',
-    )
-
-    _client = Stytch::Client.new(
-      env: 'https://foo.stytch.test',
-      project_id: 'project-test-00000000-0000-0000-0000-000000000000',
-      secret: 'secret-test-11111111-1111-1111-1111-111111111111',
-    )
-  end
-
-  it 'infers environment when not given' do
-    _client = Stytch::Client.new(
-      project_id: 'project-test-00000000-0000-0000-0000-000000000000',
-      secret: 'secret-test-11111111-1111-1111-1111-111111111111',
-    )
-  end
+  it_behaves_like "a client"
 end

--- a/spec/stytch/shared_examples_for_clients.rb
+++ b/spec/stytch/shared_examples_for_clients.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "a client" do
+  it 'accepts production config' do
+    _client = described_class.new(
+      env: :live,
+      project_id: 'project-live-00000000-0000-0000-0000-000000000000',
+      secret: 'secret-live-11111111-1111-1111-1111-111111111111',
+    )
+  end
+
+  it 'accepts testing config' do
+    _client = described_class.new(
+      env: :test,
+      project_id: 'project-test-00000000-0000-0000-0000-000000000000',
+      secret: 'secret-test-11111111-1111-1111-1111-111111111111',
+    )
+  end
+
+  it 'accepts development config' do
+    _client = described_class.new(
+      env: 'http://localhost:8000',
+      project_id: 'project-test-00000000-0000-0000-0000-000000000000',
+      secret: 'secret-test-11111111-1111-1111-1111-111111111111',
+    )
+
+    _client = described_class.new(
+      env: 'https://foo.stytch.test',
+      project_id: 'project-test-00000000-0000-0000-0000-000000000000',
+      secret: 'secret-test-11111111-1111-1111-1111-111111111111',
+    )
+  end
+
+  it 'infers environment when not given' do
+    _client = described_class.new(
+      project_id: 'project-test-00000000-0000-0000-0000-000000000000',
+      secret: 'secret-test-11111111-1111-1111-1111-111111111111',
+    )
+  end
+end


### PR DESCRIPTION
fixes #81 

1. add spec for `StytchB2B::Client` with shared examples based on `Stytch::Client`
2. move `@connection.basic_auth` to `@connection.set_basic_auth`
