### PR TITLE
Bump major version for Ruby revamp

### DIFF
--- a/lib/stytch/version.rb
+++ b/lib/stytch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stytch
-  VERSION = '5.0.2'
+  VERSION = '6.0.0'
 end


### PR DESCRIPTION
I had run a clean on #79 and didn't realize the version change was overridden