### PR TITLE
Raise error if token auth fails

### DIFF
--- a/lib/stytch/errors.rb
+++ b/lib/stytch/errors.rb
@@ -22,4 +22,17 @@ module Stytch
       super
     end
   end
+
+  class JWTExpiredError < StandardError
+    def initialize(msg = 'JWT has expired')
+      super
+    end
+  end
+
+  class TokenMissingScopeError < StandardError
+    def initialize(scope)
+      msg = "Missing required scope #{scope}"
+      super(msg)
+    end
+  end
 end

--- a/lib/stytch/version.rb
+++ b/lib/stytch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stytch
-  VERSION = '6.2.0'
+  VERSION = '6.2.1'
 end


### PR DESCRIPTION
Defines two new errors (JWTExpiredError and TokenMissingScopeError) that extend StandardError
Raises in `authenticate_token` instead of returning `nil` to protect against cases where someone may use authentication in a guard without actually checking the return value