### PR TITLE
dev: Add Rubocop for linting

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,3 +26,16 @@ jobs:
           bundler-cache: true
 
       - run: bundle exec rspec
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          # Match the minimum supported Ruby version in the gemspec.
+          ruby-version: '2.7'
+          bundler-cache: true
+
+      - run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,15 @@
+require:
+ - rubocop-rspec
+
+AllCops:
+  NewCops: disable
+  # The target Ruby version must match the one in stytch.gemspec.
+  TargetRubyVersion: 2.7
+
+Layout: { Enabled: false }
+Metrics: { Enabled: false }
+Style: { Enabled: false }
+
+RSpec/DescribedClass: { Enabled: false }
+RSpec/ExampleLength: { Enabled: false }
+RSpec/MultipleExpectations: { Enabled: false }

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -5,7 +5,9 @@ Thanks for contributing to Stytch's Ruby library! If you run into trouble, find 
 ## Setup
 
 1. Clone this repo.
-2. To test your changes locally, update your GEMFILE with `gem 'stytch', path: '../stytch'` where `../stytch` is the path to your cloned copy of stytch-ruby.
+2. Install development dependencies using [Bundler]: `bundle install`
+
+To test your changes locally in another project, update your `GEMFILE` with `gem 'stytch', path: '../stytch'` where `../stytch` is the path to your cloned copy of stytch-ruby.
 
 ## Issues and Pull Requests
 
@@ -15,4 +17,5 @@ If you have non-trivial changes you'd like us to incorporate, please open an iss
 
 When you're ready for someone to look at your issue or PR, assign `@stytchauth/client-libraries` (GitHub should do this automatically). If we don't acknowledge it within one business day, please escalate it by tagging `@stytchauth/engineering` in a comment or letting us know in [Slack].
 
+[Bundler]: https://bundler.io/
 [Slack]: https://join.slack.com/t/stytch/shared_invite/zt-nil4wo92-jApJ9Cl32cJbEd9esKkvyg

--- a/stytch.gemspec
+++ b/stytch.gemspec
@@ -30,4 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'jwt', '>= 2.3.0'
 
   spec.add_development_dependency 'rspec', '~> 3.11.0'
+  spec.add_development_dependency 'rubocop', '1.56.3'
+  spec.add_development_dependency 'rubocop-rspec', '2.24.0'
 end


### PR DESCRIPTION
This adds a required Rubocop step to the Ruby workflow.

Rubocop accepts a configuration option for the [target Ruby version], which, in our case, defaults to the lowest version number in `stytch.gemspec`.

For now, I think we should run Rubocop just once on that minimum/target Ruby version. But if we have a reason to run it as part of the test matrix, I think that would be fine too.

## Testing

1. Pull this PR to your local repo
2. `bundle` (see that `rubocop` and `rubocop-rspec` got installed)
3. `bundle exec rubocop` (should report no errors)

I also put up a PR with an intentional linter error in #95 as an example.

[target Ruby version]: https://docs.rubocop.org/rubocop/configuration.html#setting-the-target-ruby-version