### PR TITLE
dev: Enable some Rubocop Layout and Style rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,9 +6,15 @@ AllCops:
   # The target Ruby version must match the one in stytch.gemspec.
   TargetRubyVersion: 2.7
 
-Layout: { Enabled: false }
+Layout/LineLength: { Enabled: false }
+
 Metrics: { Enabled: false }
-Style: { Enabled: false }
+
+Style/Documentation: { Enabled: false }
+Style/For: { Enabled: false }
+Style/FrozenStringLiteralComment: { Enabled: false }
+Style/NumericPredicate: { Enabled: false }
+Style/StringConcatenation: { Enabled: false }
 
 RSpec/DescribedClass: { Enabled: false }
 RSpec/ExampleLength: { Enabled: false }


### PR DESCRIPTION
In #94, I chose to disable some Rubocop groups because they weren't related to code correctness. But this library does already conform to most of Rubocop's default Layout and Style rules, so we can re-enable them to keep that consistent.
