### PR TITLE
Fix local JWT auth

### DIFF
--- a/lib/stytch/b2b_sessions.rb
+++ b/lib/stytch/b2b_sessions.rb
@@ -380,7 +380,7 @@ module StytchB2B
         )
       end
 
-      decoded_jwt = authenticate_jwt_local(session_jwt: session_jwt, authorization_check: authorization_check)
+      decoded_jwt = authenticate_jwt_local(session_jwt, max_token_age_seconds: max_token_age_seconds, authorization_check: authorization_check)
       return decoded_jwt unless decoded_jwt.nil?
 
       authenticate(

--- a/lib/stytch/sessions.rb
+++ b/lib/stytch/sessions.rb
@@ -274,15 +274,17 @@ module Stytch
       reserved_claims = ['aud', 'exp', 'iat', 'iss', 'jti', 'nbf', 'sub', stytch_claim]
       custom_claims = jwt.reject { |key, _| reserved_claims.include?(key) }
       {
-        'session_id' => jwt[stytch_claim]['id'],
-        'user_id' => jwt['sub'],
-        'started_at' => jwt[stytch_claim]['started_at'],
-        'last_accessed_at' => jwt[stytch_claim]['last_accessed_at'],
-        # For JWTs that include it, prefer the inner expires_at claim.
-        'expires_at' => expires_at,
-        'attributes' => jwt[stytch_claim]['attributes'],
-        'authentication_factors' => jwt[stytch_claim]['authentication_factors'],
-        'custom_claims' => custom_claims
+        'session' => {
+          'session_id' => jwt[stytch_claim]['id'],
+          'user_id' => jwt['sub'],
+          'started_at' => jwt[stytch_claim]['started_at'],
+          'last_accessed_at' => jwt[stytch_claim]['last_accessed_at'],
+          # For JWTs that include it, prefer the inner expires_at claim.
+          'expires_at' => expires_at,
+          'attributes' => jwt[stytch_claim]['attributes'],
+          'authentication_factors' => jwt[stytch_claim]['authentication_factors'],
+          'custom_claims' => custom_claims
+        }
       }
     end
     # ENDMANUAL(Sessions::authenticate_jwt)

--- a/lib/stytch/version.rb
+++ b/lib/stytch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stytch
-  VERSION = '7.0.1'
+  VERSION = '7.0.2'
 end

--- a/spec/stytch/sessions_spec.rb
+++ b/spec/stytch/sessions_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Stytch::Sessions do
 
     session = sessions.marshal_jwt_into_session(claims)
     # The session expires an hour after `now`.
-    expect(session['expires_at']).to eq('2022-05-03T19:51:41Z')
+    expect(session['session']['expires_at']).to eq('2022-05-03T19:51:41Z')
   end
 
   it 'marshals JWT into session (old format)' do
@@ -73,7 +73,7 @@ RSpec.describe Stytch::Sessions do
     session = sessions.marshal_jwt_into_session(claims)
 
     # The "exp" claim is five minutes after `now`.
-    expect(session['expires_at']).to eq('2022-05-03T18:56:41Z')
+    expect(session['session']['expires_at']).to eq('2022-05-03T18:56:41Z')
   end
 
   private


### PR DESCRIPTION
Fixes #109 

The call to `authenticate_jwt_local` was passing `session_jwt` as a keyword argument instead of positional, which was incorrect calling conventions for the method.

## Testing
Created a session using PW auth -> called authenticate_jwt -> verified it auth'd the JWT without making a network request