### PR TITLE
Update docs and support set_email_verified

### DIFF
--- a/lib/stytch/b2b_discovery.rb
+++ b/lib/stytch/b2b_discovery.rb
@@ -257,15 +257,15 @@ module StytchB2B
       #   for more information about role assignment.
       #   The type of this field is nilable list of +EmailImplicitRoleAssignment+ (+object+).
       # mfa_methods::
-      #   The setting that controls which mfa methods can be used by Members of an Organization. The accepted values are:
+      #   The setting that controls which MFA methods can be used by Members of an Organization. The accepted values are:
       #
       #   `ALL_ALLOWED` – the default setting which allows all authentication methods to be used.
       #
-      #   `RESTRICTED` – only methods that comply with `allowed_auth_methods` can be used for authentication. This setting does not apply to Members with `is_breakglass` set to `true`.
+      #   `RESTRICTED` – only methods that comply with `allowed_mfa_methods` can be used for authentication. This setting does not apply to Members with `is_breakglass` set to `true`.
       #
       #   The type of this field is nilable +String+.
       # allowed_mfa_methods::
-      #   An array of allowed mfa authentication methods. This list is enforced when `mfa_methods` is set to `RESTRICTED`.
+      #   An array of allowed MFA authentication methods. This list is enforced when `mfa_methods` is set to `RESTRICTED`.
       #   The list's accepted values are: `sms_otp` and `totp`.
       #
       #   The type of this field is nilable list of +String+.

--- a/lib/stytch/b2b_organizations.rb
+++ b/lib/stytch/b2b_organizations.rb
@@ -138,15 +138,15 @@ module StytchB2B
     #   for more information about role assignment.
     #   The type of this field is nilable list of +EmailImplicitRoleAssignment+ (+object+).
     # mfa_methods::
-    #   The setting that controls which mfa methods can be used by Members of an Organization. The accepted values are:
+    #   The setting that controls which MFA methods can be used by Members of an Organization. The accepted values are:
     #
     #   `ALL_ALLOWED` – the default setting which allows all authentication methods to be used.
     #
-    #   `RESTRICTED` – only methods that comply with `allowed_auth_methods` can be used for authentication. This setting does not apply to Members with `is_breakglass` set to `true`.
+    #   `RESTRICTED` – only methods that comply with `allowed_mfa_methods` can be used for authentication. This setting does not apply to Members with `is_breakglass` set to `true`.
     #
     #   The type of this field is nilable +String+.
     # allowed_mfa_methods::
-    #   An array of allowed mfa authentication methods. This list is enforced when `mfa_methods` is set to `RESTRICTED`.
+    #   An array of allowed MFA authentication methods. This list is enforced when `mfa_methods` is set to `RESTRICTED`.
     #   The list's accepted values are: `sms_otp` and `totp`.
     #
     #   The type of this field is nilable list of +String+.
@@ -355,17 +355,17 @@ module StytchB2B
     # If this field is provided and a session header is passed into the request, the Member Session must have permission to perform the `update.settings.implicit-roles` action on the `stytch.organization` Resource.
     #   The type of this field is nilable list of +String+.
     # mfa_methods::
-    #   The setting that controls which mfa methods can be used by Members of an Organization. The accepted values are:
+    #   The setting that controls which MFA methods can be used by Members of an Organization. The accepted values are:
     #
     #   `ALL_ALLOWED` – the default setting which allows all authentication methods to be used.
     #
-    #   `RESTRICTED` – only methods that comply with `allowed_auth_methods` can be used for authentication. This setting does not apply to Members with `is_breakglass` set to `true`.
+    #   `RESTRICTED` – only methods that comply with `allowed_mfa_methods` can be used for authentication. This setting does not apply to Members with `is_breakglass` set to `true`.
     #
     #
-    # If this field is provided and a session header is passed into the request, the Member Session must have permission to perform the `update.settings.allowed-auth-methods` action on the `stytch.organization` Resource.
+    # If this field is provided and a session header is passed into the request, the Member Session must have permission to perform the `update.settings.allowed-mfa-methods` action on the `stytch.organization` Resource.
     #   The type of this field is nilable +String+.
     # allowed_mfa_methods::
-    #   An array of allowed mfa authentication methods. This list is enforced when `mfa_methods` is set to `RESTRICTED`.
+    #   An array of allowed MFA authentication methods. This list is enforced when `mfa_methods` is set to `RESTRICTED`.
     #   The list's accepted values are: `sms_otp` and `totp`.
     #
     #
@@ -550,7 +550,7 @@ module StytchB2B
       # is_breakglass::
       #   Identifies the Member as a break glass user - someone who has permissions to authenticate into an Organization by bypassing the Organization's settings. A break glass account is typically used for emergency purposes to gain access outside of normal authentication procedures. Refer to the [Organization object](organization-object) and its `auth_methods` and `allowed_auth_methods` fields for more details.
       #
-      # If this field is provided and a session header is passed into the request, the Member Session must have permission to perform the `update.info.is-breakglass` action on the `stytch.member` Resource.
+      # If this field is provided and a session header is passed into the request, the Member Session must have permission to perform the `update.settings.is-breakglass` action on the `stytch.member` Resource.
       #   The type of this field is nilable +Boolean+.
       # mfa_phone_number::
       #   Sets the Member's phone number. Throws an error if the Member already has a phone number. To change the Member's phone number, use the [Delete member phone number endpoint](https://stytch.com/docs/b2b/api/delete-member-mfa-phone-number) to delete the Member's existing phone number first.

--- a/lib/stytch/b2b_rbac.rb
+++ b/lib/stytch/b2b_rbac.rb
@@ -18,10 +18,9 @@ module StytchB2B
 
     # Get the active RBAC Policy for your current Stytch Project. An RBAC Policy is the canonical document that stores all defined Resources and Roles within your RBAC permissioning model.
     #
-    # When using the backend SDKs, the RBAC Policy will automatically be loaded and refreshed in the background to allow for local evaluations, eliminating the need for an extra request to Stytch.
+    # When using the backend SDKs, the RBAC Policy will be cached to allow for local evaluations, eliminating the need for an extra request to Stytch. The policy will be refreshed if an authorization check is requested and the RBAC policy was last updated more than 5 minutes ago.
     #
-    # Resources and Roles can be created and managed within the [Dashboard](/dashboard). Additionally, [Role assignment](https://stytch.com/docs/b2b/guides/rbac/role-assignment) can be programmatically managed through certain Stytch API endpoints.
-    #
+    # Resources and Roles can be created and managed within the [Dashboard](/dashboard/rbac). Additionally, [Role assignment](https://stytch.com/docs/b2b/guides/rbac/role-assignment) can be programmatically managed through certain Stytch API endpoints.
     #
     # Check out the [RBAC overview](https://stytch.com/docs/b2b/guides/rbac/overview) to learn more about Stytch's RBAC permissioning model.
     #
@@ -36,7 +35,7 @@ module StytchB2B
     #   The HTTP status code of the response. Stytch follows standard HTTP response status code patterns, e.g. 2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX are server errors.
     #   The type of this field is +Integer+.
     # policy::
-    #   The RBAC Policy document that contains all defined Roles and Resources – which are managed in the [Dashboard](/dashboard). Read more about these entities and how they work in our [RBAC overview](https://stytch.com/docs/b2b/guides/rbac/overview).
+    #   The RBAC Policy document that contains all defined Roles and Resources – which are managed in the [Dashboard](/dashboard/rbac). Read more about these entities and how they work in our [RBAC overview](https://stytch.com/docs/b2b/guides/rbac/overview).
     #   The type of this field is nilable +Policy+ (+object+).
     def policy
       headers = {}

--- a/lib/stytch/passwords.rb
+++ b/lib/stytch/passwords.rb
@@ -292,6 +292,11 @@ module Stytch
     # untrusted_metadata::
     #   The `untrusted_metadata` field contains an arbitrary JSON object of application-specific data. Untrusted metadata can be edited by end users directly via the SDK, and **cannot be used to store critical information.** See the [Metadata](https://stytch.com/docs/api/metadata) reference for complete field behavior details.
     #   The type of this field is nilable +object+.
+    # set_email_verified::
+    #   Whether to set the user's email as verified. This is a dangerous field. Incorrect use may lead to users getting erroneously
+    #                 deduplicated into one user object. This flag should only be set if you can attest that the user owns the email address in question.
+    #                 Access to this field is restricted. To enable it, please send us a note at support@stytch.com.
+    #   The type of this field is nilable +Boolean+.
     # name::
     #   The name of the user. Each field in the name object is optional.
     #   The type of this field is nilable +Name+ (+object+).
@@ -327,6 +332,7 @@ module Stytch
       pbkdf_2_config: nil,
       trusted_metadata: nil,
       untrusted_metadata: nil,
+      set_email_verified: nil,
       name: nil
     )
       headers = {}
@@ -342,6 +348,7 @@ module Stytch
       request[:pbkdf_2_config] = pbkdf_2_config unless pbkdf_2_config.nil?
       request[:trusted_metadata] = trusted_metadata unless trusted_metadata.nil?
       request[:untrusted_metadata] = untrusted_metadata unless untrusted_metadata.nil?
+      request[:set_email_verified] = set_email_verified unless set_email_verified.nil?
       request[:name] = name unless name.nil?
 
       post_request('/v1/passwords/migrate', request, headers)

--- a/lib/stytch/version.rb
+++ b/lib/stytch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stytch
-  VERSION = '7.1.0'
+  VERSION = '7.2.0'
 end


### PR DESCRIPTION
1. Docs updates
2. Adds support for `set_email_verified` in passwords/migrate