### PR TITLE
Fix Ruby RBAC options not being rendered

### DIFF
--- a/lib/stytch.rb
+++ b/lib/stytch.rb
@@ -4,6 +4,7 @@ require 'faraday'
 
 require_relative 'stytch/b2b_client'
 require_relative 'stytch/client'
+require_relative 'stytch/method_options'
 require_relative 'stytch/middleware'
 require_relative 'stytch/version'
 

--- a/lib/stytch/b2b_magic_links.rb
+++ b/lib/stytch/b2b_magic_links.rb
@@ -151,6 +151,25 @@ module StytchB2B
     end
 
     class Email
+      class InviteRequestOptions
+        # Optional authorization object.
+        # Pass in an active Stytch Member session token or session JWT and the request
+        # will be run using that member's permissions.
+        attr_accessor :authorization
+
+        def initialize(
+          authorization: nil
+        )
+          @authorization = authorization
+        end
+
+        def to_headers
+          headers = {}
+          headers.merge!(@authorization.to_headers) if authorization
+          headers
+        end
+      end
+
       include Stytch::RequestHelper
       attr_reader :discovery
 
@@ -308,7 +327,7 @@ module StytchB2B
       #   The type of this field is +Integer+.
       #
       # == Method Options:
-      # This method supports an optional +InviteRequestOptions+ object which will modify the headers sent in the HTTP request.
+      # This method supports an optional +StytchB2B::MagicLinks::Email::InviteRequestOptions+ object which will modify the headers sent in the HTTP request.
       def invite(
         organization_id:,
         email_address:,

--- a/lib/stytch/b2b_organizations.rb
+++ b/lib/stytch/b2b_organizations.rb
@@ -9,45 +9,45 @@
 require_relative 'request_helper'
 
 module StytchB2B
-  class UpdateRequestOptions
-    # Optional authorization object.
-    # Pass in an active Stytch Member session token or session JWT and the request
-    # will be run using that member's permissions.
-    attr_accessor :authorization
-
-    def initialize(
-      authorization: nil
-    )
-      @authorization = authorization
-    end
-
-    def to_headers
-      headers = {}
-      headers.merge!(@authorization.to_headers) if authorization
-      headers
-    end
-  end
-
-  class DeleteRequestOptions
-    # Optional authorization object.
-    # Pass in an active Stytch Member session token or session JWT and the request
-    # will be run using that member's permissions.
-    attr_accessor :authorization
-
-    def initialize(
-      authorization: nil
-    )
-      @authorization = authorization
-    end
-
-    def to_headers
-      headers = {}
-      headers.merge!(@authorization.to_headers) if authorization
-      headers
-    end
-  end
-
   class Organizations
+    class UpdateRequestOptions
+      # Optional authorization object.
+      # Pass in an active Stytch Member session token or session JWT and the request
+      # will be run using that member's permissions.
+      attr_accessor :authorization
+
+      def initialize(
+        authorization: nil
+      )
+        @authorization = authorization
+      end
+
+      def to_headers
+        headers = {}
+        headers.merge!(@authorization.to_headers) if authorization
+        headers
+      end
+    end
+
+    class DeleteRequestOptions
+      # Optional authorization object.
+      # Pass in an active Stytch Member session token or session JWT and the request
+      # will be run using that member's permissions.
+      attr_accessor :authorization
+
+      def initialize(
+        authorization: nil
+      )
+        @authorization = authorization
+      end
+
+      def to_headers
+        headers = {}
+        headers.merge!(@authorization.to_headers) if authorization
+        headers
+      end
+    end
+
     include Stytch::RequestHelper
     attr_reader :members
 
@@ -385,7 +385,7 @@ module StytchB2B
     #   The type of this field is +Integer+.
     #
     # == Method Options:
-    # This method supports an optional +UpdateRequestOptions+ object which will modify the headers sent in the HTTP request.
+    # This method supports an optional +StytchB2B::Organizations::UpdateRequestOptions+ object which will modify the headers sent in the HTTP request.
     def update(
       organization_id:,
       organization_name: nil,
@@ -449,7 +449,7 @@ module StytchB2B
     #   The type of this field is +Integer+.
     #
     # == Method Options:
-    # This method supports an optional +DeleteRequestOptions+ object which will modify the headers sent in the HTTP request.
+    # This method supports an optional +StytchB2B::Organizations::DeleteRequestOptions+ object which will modify the headers sent in the HTTP request.
     def delete(
       organization_id:,
       method_options: nil
@@ -510,6 +510,158 @@ module StytchB2B
     end
 
     class Members
+      class UpdateRequestOptions
+        # Optional authorization object.
+        # Pass in an active Stytch Member session token or session JWT and the request
+        # will be run using that member's permissions.
+        attr_accessor :authorization
+
+        def initialize(
+          authorization: nil
+        )
+          @authorization = authorization
+        end
+
+        def to_headers
+          headers = {}
+          headers.merge!(@authorization.to_headers) if authorization
+          headers
+        end
+      end
+
+      class DeleteRequestOptions
+        # Optional authorization object.
+        # Pass in an active Stytch Member session token or session JWT and the request
+        # will be run using that member's permissions.
+        attr_accessor :authorization
+
+        def initialize(
+          authorization: nil
+        )
+          @authorization = authorization
+        end
+
+        def to_headers
+          headers = {}
+          headers.merge!(@authorization.to_headers) if authorization
+          headers
+        end
+      end
+
+      class ReactivateRequestOptions
+        # Optional authorization object.
+        # Pass in an active Stytch Member session token or session JWT and the request
+        # will be run using that member's permissions.
+        attr_accessor :authorization
+
+        def initialize(
+          authorization: nil
+        )
+          @authorization = authorization
+        end
+
+        def to_headers
+          headers = {}
+          headers.merge!(@authorization.to_headers) if authorization
+          headers
+        end
+      end
+
+      class DeleteMFAPhoneNumberRequestOptions
+        # Optional authorization object.
+        # Pass in an active Stytch Member session token or session JWT and the request
+        # will be run using that member's permissions.
+        attr_accessor :authorization
+
+        def initialize(
+          authorization: nil
+        )
+          @authorization = authorization
+        end
+
+        def to_headers
+          headers = {}
+          headers.merge!(@authorization.to_headers) if authorization
+          headers
+        end
+      end
+
+      class DeleteTOTPRequestOptions
+        # Optional authorization object.
+        # Pass in an active Stytch Member session token or session JWT and the request
+        # will be run using that member's permissions.
+        attr_accessor :authorization
+
+        def initialize(
+          authorization: nil
+        )
+          @authorization = authorization
+        end
+
+        def to_headers
+          headers = {}
+          headers.merge!(@authorization.to_headers) if authorization
+          headers
+        end
+      end
+
+      class SearchRequestOptions
+        # Optional authorization object.
+        # Pass in an active Stytch Member session token or session JWT and the request
+        # will be run using that member's permissions.
+        attr_accessor :authorization
+
+        def initialize(
+          authorization: nil
+        )
+          @authorization = authorization
+        end
+
+        def to_headers
+          headers = {}
+          headers.merge!(@authorization.to_headers) if authorization
+          headers
+        end
+      end
+
+      class DeletePasswordRequestOptions
+        # Optional authorization object.
+        # Pass in an active Stytch Member session token or session JWT and the request
+        # will be run using that member's permissions.
+        attr_accessor :authorization
+
+        def initialize(
+          authorization: nil
+        )
+          @authorization = authorization
+        end
+
+        def to_headers
+          headers = {}
+          headers.merge!(@authorization.to_headers) if authorization
+          headers
+        end
+      end
+
+      class CreateRequestOptions
+        # Optional authorization object.
+        # Pass in an active Stytch Member session token or session JWT and the request
+        # will be run using that member's permissions.
+        attr_accessor :authorization
+
+        def initialize(
+          authorization: nil
+        )
+          @authorization = authorization
+        end
+
+        def to_headers
+          headers = {}
+          headers.merge!(@authorization.to_headers) if authorization
+          headers
+        end
+      end
+
       include Stytch::RequestHelper
       attr_reader :oauth_providers
 
@@ -621,7 +773,7 @@ module StytchB2B
       #   The type of this field is +Integer+.
       #
       # == Method Options:
-      # This method supports an optional +UpdateRequestOptions+ object which will modify the headers sent in the HTTP request.
+      # This method supports an optional +StytchB2B::Organizations::Members::UpdateRequestOptions+ object which will modify the headers sent in the HTTP request.
       def update(
         organization_id:,
         member_id:,
@@ -677,7 +829,7 @@ module StytchB2B
       #   The type of this field is +Integer+.
       #
       # == Method Options:
-      # This method supports an optional +DeleteRequestOptions+ object which will modify the headers sent in the HTTP request.
+      # This method supports an optional +StytchB2B::Organizations::Members::DeleteRequestOptions+ object which will modify the headers sent in the HTTP request.
       def delete(
         organization_id:,
         member_id:,
@@ -717,7 +869,7 @@ module StytchB2B
       #   The type of this field is +Integer+.
       #
       # == Method Options:
-      # This method supports an optional +ReactivateRequestOptions+ object which will modify the headers sent in the HTTP request.
+      # This method supports an optional +StytchB2B::Organizations::Members::ReactivateRequestOptions+ object which will modify the headers sent in the HTTP request.
       def reactivate(
         organization_id:,
         member_id:,
@@ -766,7 +918,7 @@ module StytchB2B
       #   The type of this field is +Integer+.
       #
       # == Method Options:
-      # This method supports an optional +DeleteMFAPhoneNumberRequestOptions+ object which will modify the headers sent in the HTTP request.
+      # This method supports an optional +StytchB2B::Organizations::Members::DeleteMFAPhoneNumberRequestOptions+ object which will modify the headers sent in the HTTP request.
       def delete_mfa_phone_number(
         organization_id:,
         member_id:,
@@ -836,7 +988,7 @@ module StytchB2B
       #   The type of this field is +Integer+.
       #
       # == Method Options:
-      # This method supports an optional +SearchRequestOptions+ object which will modify the headers sent in the HTTP request.
+      # This method supports an optional +StytchB2B::Organizations::Members::SearchRequestOptions+ object which will modify the headers sent in the HTTP request.
       def search(
         organization_ids:,
         cursor: nil,
@@ -885,7 +1037,7 @@ module StytchB2B
       #   The type of this field is +Integer+.
       #
       # == Method Options:
-      # This method supports an optional +DeletePasswordRequestOptions+ object which will modify the headers sent in the HTTP request.
+      # This method supports an optional +StytchB2B::Organizations::Members::DeletePasswordRequestOptions+ object which will modify the headers sent in the HTTP request.
       def delete_password(
         organization_id:,
         member_password_id:,
@@ -985,7 +1137,7 @@ module StytchB2B
       #   The type of this field is +Integer+.
       #
       # == Method Options:
-      # This method supports an optional +CreateRequestOptions+ object which will modify the headers sent in the HTTP request.
+      # This method supports an optional +StytchB2B::Organizations::Members::CreateRequestOptions+ object which will modify the headers sent in the HTTP request.
       def create(
         organization_id:,
         email_address:,

--- a/lib/stytch/b2b_scim.rb
+++ b/lib/stytch/b2b_scim.rb
@@ -20,6 +20,139 @@ module StytchB2B
     end
 
     class Connections
+      class UpdateRequestOptions
+        # Optional authorization object.
+        # Pass in an active Stytch Member session token or session JWT and the request
+        # will be run using that member's permissions.
+        attr_accessor :authorization
+
+        def initialize(
+          authorization: nil
+        )
+          @authorization = authorization
+        end
+
+        def to_headers
+          headers = {}
+          headers.merge!(@authorization.to_headers) if authorization
+          headers
+        end
+      end
+
+      class DeleteRequestOptions
+        # Optional authorization object.
+        # Pass in an active Stytch Member session token or session JWT and the request
+        # will be run using that member's permissions.
+        attr_accessor :authorization
+
+        def initialize(
+          authorization: nil
+        )
+          @authorization = authorization
+        end
+
+        def to_headers
+          headers = {}
+          headers.merge!(@authorization.to_headers) if authorization
+          headers
+        end
+      end
+
+      class RotateStartRequestOptions
+        # Optional authorization object.
+        # Pass in an active Stytch Member session token or session JWT and the request
+        # will be run using that member's permissions.
+        attr_accessor :authorization
+
+        def initialize(
+          authorization: nil
+        )
+          @authorization = authorization
+        end
+
+        def to_headers
+          headers = {}
+          headers.merge!(@authorization.to_headers) if authorization
+          headers
+        end
+      end
+
+      class RotateCompleteRequestOptions
+        # Optional authorization object.
+        # Pass in an active Stytch Member session token or session JWT and the request
+        # will be run using that member's permissions.
+        attr_accessor :authorization
+
+        def initialize(
+          authorization: nil
+        )
+          @authorization = authorization
+        end
+
+        def to_headers
+          headers = {}
+          headers.merge!(@authorization.to_headers) if authorization
+          headers
+        end
+      end
+
+      class RotateCancelRequestOptions
+        # Optional authorization object.
+        # Pass in an active Stytch Member session token or session JWT and the request
+        # will be run using that member's permissions.
+        attr_accessor :authorization
+
+        def initialize(
+          authorization: nil
+        )
+          @authorization = authorization
+        end
+
+        def to_headers
+          headers = {}
+          headers.merge!(@authorization.to_headers) if authorization
+          headers
+        end
+      end
+
+      class CreateRequestOptions
+        # Optional authorization object.
+        # Pass in an active Stytch Member session token or session JWT and the request
+        # will be run using that member's permissions.
+        attr_accessor :authorization
+
+        def initialize(
+          authorization: nil
+        )
+          @authorization = authorization
+        end
+
+        def to_headers
+          headers = {}
+          headers.merge!(@authorization.to_headers) if authorization
+          headers
+        end
+      end
+
+      class GetRequestOptions
+        # Optional authorization object.
+        # Pass in an active Stytch Member session token or session JWT and the request
+        # will be run using that member's permissions.
+        attr_accessor :authorization
+
+        def initialize(
+          authorization: nil
+        )
+          @authorization = authorization
+        end
+
+        def to_headers
+          headers = {}
+          headers.merge!(@authorization.to_headers) if authorization
+          headers
+        end
+      end
+
       include Stytch::RequestHelper
 
       def initialize(connection)
@@ -58,7 +191,7 @@ module StytchB2B
       #   The type of this field is nilable +SCIMConnection+ (+object+).
       #
       # == Method Options:
-      # This method supports an optional +UpdateRequestOptions+ object which will modify the headers sent in the HTTP request.
+      # This method supports an optional +StytchB2B::SCIM::Connections::UpdateRequestOptions+ object which will modify the headers sent in the HTTP request.
       def update(
         organization_id:,
         connection_id:,
@@ -100,7 +233,7 @@ module StytchB2B
       #   The type of this field is +Integer+.
       #
       # == Method Options:
-      # This method supports an optional +DeleteRequestOptions+ object which will modify the headers sent in the HTTP request.
+      # This method supports an optional +StytchB2B::SCIM::Connections::DeleteRequestOptions+ object which will modify the headers sent in the HTTP request.
       def delete(
         organization_id:,
         connection_id:,
@@ -134,7 +267,7 @@ module StytchB2B
       #   The type of this field is nilable +SCIMConnectionWithNextToken+ (+object+).
       #
       # == Method Options:
-      # This method supports an optional +RotateStartRequestOptions+ object which will modify the headers sent in the HTTP request.
+      # This method supports an optional +StytchB2B::SCIM::Connections::RotateStartRequestOptions+ object which will modify the headers sent in the HTTP request.
       def rotate_start(
         organization_id:,
         connection_id:,
@@ -170,7 +303,7 @@ module StytchB2B
       #   The type of this field is nilable +SCIMConnection+ (+object+).
       #
       # == Method Options:
-      # This method supports an optional +RotateCompleteRequestOptions+ object which will modify the headers sent in the HTTP request.
+      # This method supports an optional +StytchB2B::SCIM::Connections::RotateCompleteRequestOptions+ object which will modify the headers sent in the HTTP request.
       def rotate_complete(
         organization_id:,
         connection_id:,
@@ -206,7 +339,7 @@ module StytchB2B
       #   The type of this field is nilable +SCIMConnection+ (+object+).
       #
       # == Method Options:
-      # This method supports an optional +RotateCancelRequestOptions+ object which will modify the headers sent in the HTTP request.
+      # This method supports an optional +StytchB2B::SCIM::Connections::RotateCancelRequestOptions+ object which will modify the headers sent in the HTTP request.
       def rotate_cancel(
         organization_id:,
         connection_id:,
@@ -245,7 +378,7 @@ module StytchB2B
       #   The type of this field is nilable +SCIMConnectionWithToken+ (+object+).
       #
       # == Method Options:
-      # This method supports an optional +CreateRequestOptions+ object which will modify the headers sent in the HTTP request.
+      # This method supports an optional +StytchB2B::SCIM::Connections::CreateRequestOptions+ object which will modify the headers sent in the HTTP request.
       def create(
         organization_id:,
         display_name: nil,
@@ -281,7 +414,7 @@ module StytchB2B
       #   The type of this field is +Integer+.
       #
       # == Method Options:
-      # This method supports an optional +GetRequestOptions+ object which will modify the headers sent in the HTTP request.
+      # This method supports an optional +StytchB2B::SCIM::Connections::GetRequestOptions+ object which will modify the headers sent in the HTTP request.
       def get(
         organization_id:,
         method_options: nil

--- a/lib/stytch/b2b_sso.rb
+++ b/lib/stytch/b2b_sso.rb
@@ -9,45 +9,45 @@
 require_relative 'request_helper'
 
 module StytchB2B
-  class GetConnectionsRequestOptions
-    # Optional authorization object.
-    # Pass in an active Stytch Member session token or session JWT and the request
-    # will be run using that member's permissions.
-    attr_accessor :authorization
-
-    def initialize(
-      authorization: nil
-    )
-      @authorization = authorization
-    end
-
-    def to_headers
-      headers = {}
-      headers.merge!(@authorization.to_headers) if authorization
-      headers
-    end
-  end
-
-  class DeleteConnectionRequestOptions
-    # Optional authorization object.
-    # Pass in an active Stytch Member session token or session JWT and the request
-    # will be run using that member's permissions.
-    attr_accessor :authorization
-
-    def initialize(
-      authorization: nil
-    )
-      @authorization = authorization
-    end
-
-    def to_headers
-      headers = {}
-      headers.merge!(@authorization.to_headers) if authorization
-      headers
-    end
-  end
-
   class SSO
+    class GetConnectionsRequestOptions
+      # Optional authorization object.
+      # Pass in an active Stytch Member session token or session JWT and the request
+      # will be run using that member's permissions.
+      attr_accessor :authorization
+
+      def initialize(
+        authorization: nil
+      )
+        @authorization = authorization
+      end
+
+      def to_headers
+        headers = {}
+        headers.merge!(@authorization.to_headers) if authorization
+        headers
+      end
+    end
+
+    class DeleteConnectionRequestOptions
+      # Optional authorization object.
+      # Pass in an active Stytch Member session token or session JWT and the request
+      # will be run using that member's permissions.
+      attr_accessor :authorization
+
+      def initialize(
+        authorization: nil
+      )
+        @authorization = authorization
+      end
+
+      def to_headers
+        headers = {}
+        headers.merge!(@authorization.to_headers) if authorization
+        headers
+      end
+    end
+
     include Stytch::RequestHelper
     attr_reader :oidc, :saml
 
@@ -81,7 +81,7 @@ module StytchB2B
     #   The type of this field is +Integer+.
     #
     # == Method Options:
-    # This method supports an optional +GetConnectionsRequestOptions+ object which will modify the headers sent in the HTTP request.
+    # This method supports an optional +StytchB2B::SSO::GetConnectionsRequestOptions+ object which will modify the headers sent in the HTTP request.
     def get_connections(
       organization_id:,
       method_options: nil
@@ -116,7 +116,7 @@ module StytchB2B
     #   The type of this field is +Integer+.
     #
     # == Method Options:
-    # This method supports an optional +DeleteConnectionRequestOptions+ object which will modify the headers sent in the HTTP request.
+    # This method supports an optional +StytchB2B::SSO::DeleteConnectionRequestOptions+ object which will modify the headers sent in the HTTP request.
     def delete_connection(
       organization_id:,
       connection_id:,
@@ -253,6 +253,44 @@ module StytchB2B
     end
 
     class OIDC
+      class CreateConnectionRequestOptions
+        # Optional authorization object.
+        # Pass in an active Stytch Member session token or session JWT and the request
+        # will be run using that member's permissions.
+        attr_accessor :authorization
+
+        def initialize(
+          authorization: nil
+        )
+          @authorization = authorization
+        end
+
+        def to_headers
+          headers = {}
+          headers.merge!(@authorization.to_headers) if authorization
+          headers
+        end
+      end
+
+      class UpdateConnectionRequestOptions
+        # Optional authorization object.
+        # Pass in an active Stytch Member session token or session JWT and the request
+        # will be run using that member's permissions.
+        attr_accessor :authorization
+
+        def initialize(
+          authorization: nil
+        )
+          @authorization = authorization
+        end
+
+        def to_headers
+          headers = {}
+          headers.merge!(@authorization.to_headers) if authorization
+          headers
+        end
+      end
+
       include Stytch::RequestHelper
 
       def initialize(connection)
@@ -282,7 +320,7 @@ module StytchB2B
       #   The type of this field is nilable +OIDCConnection+ (+object+).
       #
       # == Method Options:
-      # This method supports an optional +CreateConnectionRequestOptions+ object which will modify the headers sent in the HTTP request.
+      # This method supports an optional +StytchB2B::SSO::OIDC::CreateConnectionRequestOptions+ object which will modify the headers sent in the HTTP request.
       def create_connection(
         organization_id:,
         display_name: nil,
@@ -364,7 +402,7 @@ module StytchB2B
       #   The type of this field is nilable +String+.
       #
       # == Method Options:
-      # This method supports an optional +UpdateConnectionRequestOptions+ object which will modify the headers sent in the HTTP request.
+      # This method supports an optional +StytchB2B::SSO::OIDC::UpdateConnectionRequestOptions+ object which will modify the headers sent in the HTTP request.
       def update_connection(
         organization_id:,
         connection_id:,
@@ -395,6 +433,82 @@ module StytchB2B
     end
 
     class SAML
+      class CreateConnectionRequestOptions
+        # Optional authorization object.
+        # Pass in an active Stytch Member session token or session JWT and the request
+        # will be run using that member's permissions.
+        attr_accessor :authorization
+
+        def initialize(
+          authorization: nil
+        )
+          @authorization = authorization
+        end
+
+        def to_headers
+          headers = {}
+          headers.merge!(@authorization.to_headers) if authorization
+          headers
+        end
+      end
+
+      class UpdateConnectionRequestOptions
+        # Optional authorization object.
+        # Pass in an active Stytch Member session token or session JWT and the request
+        # will be run using that member's permissions.
+        attr_accessor :authorization
+
+        def initialize(
+          authorization: nil
+        )
+          @authorization = authorization
+        end
+
+        def to_headers
+          headers = {}
+          headers.merge!(@authorization.to_headers) if authorization
+          headers
+        end
+      end
+
+      class UpdateByURLRequestOptions
+        # Optional authorization object.
+        # Pass in an active Stytch Member session token or session JWT and the request
+        # will be run using that member's permissions.
+        attr_accessor :authorization
+
+        def initialize(
+          authorization: nil
+        )
+          @authorization = authorization
+        end
+
+        def to_headers
+          headers = {}
+          headers.merge!(@authorization.to_headers) if authorization
+          headers
+        end
+      end
+
+      class DeleteVerificationCertificateRequestOptions
+        # Optional authorization object.
+        # Pass in an active Stytch Member session token or session JWT and the request
+        # will be run using that member's permissions.
+        attr_accessor :authorization
+
+        def initialize(
+          authorization: nil
+        )
+          @authorization = authorization
+        end
+
+        def to_headers
+          headers = {}
+          headers.merge!(@authorization.to_headers) if authorization
+          headers
+        end
+      end
+
       include Stytch::RequestHelper
 
       def initialize(connection)
@@ -424,7 +538,7 @@ module StytchB2B
       #   The type of this field is nilable +SAMLConnection+ (+object+).
       #
       # == Method Options:
-      # This method supports an optional +CreateConnectionRequestOptions+ object which will modify the headers sent in the HTTP request.
+      # This method supports an optional +StytchB2B::SSO::SAML::CreateConnectionRequestOptions+ object which will modify the headers sent in the HTTP request.
       def create_connection(
         organization_id:,
         display_name: nil,
@@ -497,7 +611,7 @@ module StytchB2B
       #   The type of this field is nilable +SAMLConnection+ (+object+).
       #
       # == Method Options:
-      # This method supports an optional +UpdateConnectionRequestOptions+ object which will modify the headers sent in the HTTP request.
+      # This method supports an optional +StytchB2B::SSO::SAML::UpdateConnectionRequestOptions+ object which will modify the headers sent in the HTTP request.
       def update_connection(
         organization_id:,
         connection_id:,
@@ -559,7 +673,7 @@ module StytchB2B
       #   The type of this field is nilable +SAMLConnection+ (+object+).
       #
       # == Method Options:
-      # This method supports an optional +UpdateByURLRequestOptions+ object which will modify the headers sent in the HTTP request.
+      # This method supports an optional +StytchB2B::SSO::SAML::UpdateByURLRequestOptions+ object which will modify the headers sent in the HTTP request.
       def update_by_url(
         organization_id:,
         connection_id:,
@@ -604,7 +718,7 @@ module StytchB2B
       #   The type of this field is +Integer+.
       #
       # == Method Options:
-      # This method supports an optional +DeleteVerificationCertificateRequestOptions+ object which will modify the headers sent in the HTTP request.
+      # This method supports an optional +StytchB2B::SSO::SAML::DeleteVerificationCertificateRequestOptions+ object which will modify the headers sent in the HTTP request.
       def delete_verification_certificate(
         organization_id:,
         connection_id:,

--- a/lib/stytch/version.rb
+++ b/lib/stytch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stytch
-  VERSION = '7.8.1'
+  VERSION = '8.0.0'
 end


### PR DESCRIPTION
This is a MAJOR upgrade -- we weren't previously rendering RBAC method options correctly, which meant most never showed up. Those that _did_ show up were not actually showing up in a helpful location, so they are now being nested under the appropriate class that needs those options.

![image](https://github.com/stytchauth/stytch-ruby/assets/119902778/2d0b39b9-60f8-4fcd-b9d7-3afc574bfa2e)
