### PR TITLE
Support wildcard scopes in M2M auth

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 require:
- - rubocop-rspec
+  - rubocop-rspec
 
 AllCops:
   NewCops: disable

--- a/lib/stytch/errors.rb
+++ b/lib/stytch/errors.rb
@@ -49,4 +49,11 @@ module Stytch
       super(msg)
     end
   end
+
+  class M2MPermissionError < StandardError
+    def initialize(has_scopes, missing_scope)
+      msg = "Missing required scope #{missing_scope} for M2M request with scopes #{has_scopes}"
+      super(msg)
+    end
+  end
 end

--- a/lib/stytch/errors.rb
+++ b/lib/stytch/errors.rb
@@ -51,8 +51,8 @@ module Stytch
   end
 
   class M2MPermissionError < StandardError
-    def initialize(has_scopes, missing_scope)
-      msg = "Missing required scope #{missing_scope} for M2M request with scopes #{has_scopes}"
+    def initialize(has_scopes, required_scopes)
+      msg = "Missing at least one required scope from #{required_scopes} for M2M request with scopes #{has_scopes}"
       super(msg)
     end
   end

--- a/lib/stytch/m2m.rb
+++ b/lib/stytch/m2m.rb
@@ -96,6 +96,10 @@ module Stytch
     # max_token_age::
     #   The maximum possible lifetime in seconds for the token to be valid.
     #   The type of this field is nilable +Integer+.
+    # scope_authorization_func::
+    #   A function to check if the token has the required scopes. This defaults to a function that assumes
+    #   scopes are either direct string matches or written in the form "action:resource". See the
+    #   documentation for +perform_authorization_check+ for more information.
     # == Returns:
     # +nil+ if the token could not be validated, or an object with the following fields:
     # scopes::
@@ -107,7 +111,12 @@ module Stytch
     # custom_claims::
     #   A map of custom claims present in the token.
     #   The type of this field is +object+.
-    def authenticate_token(access_token:, required_scopes: nil, max_token_age: nil)
+    def authenticate_token(
+      access_token:,
+      required_scopes: nil,
+      max_token_age: nil,
+      scope_authorization_func: method(:perform_authorization_check)
+    )
       # Intentionally allow this to re-raise if authentication fails
       decoded_jwt = authenticate_token_local(access_token)
 
@@ -118,13 +127,25 @@ module Stytch
 
       resp = marshal_jwt_into_response(decoded_jwt)
 
-      perform_authorization_check(resp['scopes'], required_scopes) unless required_scopes.nil?
+      unless required_scopes.nil?
+        is_authorized = scope_authorization_func.call(
+          has_scopes: resp['scopes'],
+          required_scopes: required_scopes
+        )
+        raise M2MPermissionError.new(resp['scopes'], required_scopes) unless is_authorized
+      end
 
       resp
     end
 
     # Performs an authorization check against an M2M client and a set of required
-    # scopes. If the check fails, a PermissionError will be raised.
+    # scopes. Returns true if the client has all the required scopes, false otherwise.
+    # A scope can match if the client has a wildcard resource or the specific resource.
+    # This function assumes that scopes are of the form "action:resource" or just
+    # "specific_scope". It is _also_ possible to represent scopes as "resource:action",
+    # but it is ultimately up to the developer to ensure consistency in the scopes format.
+    # Note that a scope of "*" will only match another literal "*" because wildcards are
+    # *not* supported in the prefix piece of a scope.
     def perform_authorization_check(
       has_scopes:,
       required_scopes:
@@ -132,21 +153,23 @@ module Stytch
       client_scopes = Hash.new { |hash, key| hash[key] = Set.new }
       has_scopes.each do |scope|
         action = scope
-        resource = '*'
+        resource = '-'
         action, resource = scope.split(':') if scope.include?(':')
         client_scopes[action].add(resource)
       end
 
       required_scopes.each do |required_scope|
         required_action = required_scope
-        required_resource = '*'
+        required_resource = '-'
         required_action, required_resource = required_scope.split(':') if required_scope.include?(':')
-        raise M2MPermissionError.new(has_scopes, required_scope) unless client_scopes.key?(required_action)
+        return false unless client_scopes.key?(required_action)
 
         resources = client_scopes[required_action]
         # The client can either have a wildcard resource or the specific resource
-        raise PermissionError.new(has_scopes, required_scope) unless resources.include?('*') || resources.include?(required_resource)
+        return false unless resources.include?('*') || resources.include?(required_resource)
       end
+
+      true
     end
 
     # Parse a M2M token and verify the signature locally (without calling /authenticate in the API)

--- a/lib/stytch/version.rb
+++ b/lib/stytch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stytch
-  VERSION = '9.0.0'
+  VERSION = '9.1.0'
 end

--- a/spec/stytch/m2m_spec.rb
+++ b/spec/stytch/m2m_spec.rb
@@ -7,53 +7,63 @@ RSpec.describe Stytch::M2M do
     has = ['read:user', 'write:user']
     needs = ['read:user']
 
-    expect do
-      m2m.perform_authorization_check(has_scopes: has, required_scopes: needs)
-    end.not_to raise_error
+    res = m2m.perform_authorization_check(has_scopes: has, required_scopes: needs)
+    expect(res).to eq(true)
   end
 
   it 'handles multiple required scopes' do
     has = ['read:users', 'write:users', 'read:books']
     needs = ['read:users', 'read:books']
 
-    expect do
-      m2m.perform_authorization_check(has_scopes: has, required_scopes: needs)
-    end.not_to raise_error
+    res = m2m.perform_authorization_check(has_scopes: has, required_scopes: needs)
+    expect(res).to eq(true)
   end
 
   it 'handles simple scopes' do
     has = %w[read_users write_users]
     needs = ['read_users']
 
-    expect do
-      m2m.perform_authorization_check(has_scopes: has, required_scopes: needs)
-    end.not_to raise_error
+    res = m2m.perform_authorization_check(has_scopes: has, required_scopes: needs)
+    expect(res).to eq(true)
   end
 
   it 'handles wildcard resources' do
     has = ['read:*', 'write:*']
     needs = ['read:users']
 
-    expect do
-      m2m.perform_authorization_check(has_scopes: has, required_scopes: needs)
-    end.not_to raise_error
+    res = m2m.perform_authorization_check(has_scopes: has, required_scopes: needs)
+    expect(res).to eq(true)
   end
 
   it 'raises an exception for missing scopes' do
     has = ['read:users']
     needs = ['write:users']
 
-    expect do
-      m2m.perform_authorization_check(has_scopes: has, required_scopes: needs)
-    end.to raise_error(Stytch::M2MPermissionError)
+    res = m2m.perform_authorization_check(has_scopes: has, required_scopes: needs)
+    expect(res).to eq(false)
   end
 
   it 'raises an exception for missing scopes with wildcards' do
     has = ['read:users', 'write:*']
     needs = ['delete:books']
 
-    expect do
-      m2m.perform_authorization_check(has_scopes: has, required_scopes: needs)
-    end.to raise_error(Stytch::M2MPermissionError)
+    res = m2m.perform_authorization_check(has_scopes: has, required_scopes: needs)
+    expect(res).to eq(false)
+  end
+
+  it 'has simple scope and wants specific scope' do
+    has = ['read']
+    needs = ['read:users']
+
+    res = m2m.perform_authorization_check(has_scopes: has, required_scopes: needs)
+    expect(res).to eq(false)
+  end
+
+  it 'has specific scope and wants simple scope' do
+    has = ['read:users']
+    needs = ['read']
+
+    res = m2m.perform_authorization_check(has_scopes: has, required_scopes: needs)
+    expect(res).to eq(false)
   end
 end

--- a/spec/stytch/m2m_spec.rb
+++ b/spec/stytch/m2m_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+RSpec.describe Stytch::M2M do
+  let(:m2m) { Stytch::M2M.new(nil, '') }
+
+  it 'handles basic m2m auth' do
+    has = ['read:user', 'write:user']
+    needs = ['read:user']
+
+    expect do
+      m2m.perform_authorization_check(has_scopes: has, required_scopes: needs)
+    end.not_to raise_error
+  end
+
+  it 'handles multiple required scopes' do
+    has = ['read:users', 'write:users', 'read:books']
+    needs = ['read:users', 'read:books']
+
+    expect do
+      m2m.perform_authorization_check(has_scopes: has, required_scopes: needs)
+    end.not_to raise_error
+  end
+
+  it 'handles simple scopes' do
+    has = %w[read_users write_users]
+    needs = ['read_users']
+
+    expect do
+      m2m.perform_authorization_check(has_scopes: has, required_scopes: needs)
+    end.not_to raise_error
+  end
+
+  it 'handles wildcard resources' do
+    has = ['read:*', 'write:*']
+    needs = ['read:users']
+
+    expect do
+      m2m.perform_authorization_check(has_scopes: has, required_scopes: needs)
+    end.not_to raise_error
+  end
+
+  it 'raises an exception for missing scopes' do
+    has = ['read:users']
+    needs = ['write:users']
+
+    expect do
+      m2m.perform_authorization_check(has_scopes: has, required_scopes: needs)
+    end.to raise_error(Stytch::M2MPermissionError)
+  end
+
+  it 'raises an exception for missing scopes with wildcards' do
+    has = ['read:users', 'write:*']
+    needs = ['delete:books']
+
+    expect do
+      m2m.perform_authorization_check(has_scopes: has, required_scopes: needs)
+    end.to raise_error(Stytch::M2MPermissionError)
+  end
+end

--- a/spec/stytch/sessions_spec.rb
+++ b/spec/stytch/sessions_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Stytch::Sessions do
       'sub' => 'user-live-fde03dd1-fff7-4b3c-9b31-ead3fbc224de',
       'iat' => now.to_time.to_i,
       'nbf' => now.to_time.to_i,
-      'exp' => now.to_time.to_i + 5 * 60,  # five minutes
+      'exp' => now.to_time.to_i + 5 * 60, # five minutes
       'iss' => 'stytch.com/' + project_id,
       'aud' => [project_id]
     }

--- a/stytch.gemspec
+++ b/stytch.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'jwt', '>= 2.3.0'
 
   spec.add_development_dependency 'rspec', '~> 3.11.0'
-  spec.add_development_dependency 'rubocop', '1.56.3'
+  spec.add_development_dependency 'rubocop', '1.64.1'
   spec.add_development_dependency 'rubocop-rspec', '2.24.0'
 end


### PR DESCRIPTION
This PR adds support for wildcard scopes in M2M auth.
This means that an M2M client can have a scope like `read:*` and if given a required scope of `read:foo`, authentication will be allowed.

This does *not* affect "simple" scopes like `read` or `read_users` -- only scopes with a separating `:` are supported.

Furthermore, the assumption is that the scopes will be given as `action:resource`, though it is technically possible to assign in a different way like `users:read`, though in that case, a scope of `users:*` would **not** match a required scope of `read:users`. But as long as an application is consistent, this would be allowed.

Furthermore, a scope of just `*` does **not** get interpreted as an "omniscient" client -- instead, this is seen as the literal character `*` and gets matched similarly to `read_users` as mentioned above.