### PR TITLE
Fix double JSON.parse of M2M::token

### DIFF
--- a/lib/stytch/m2m.rb
+++ b/lib/stytch/m2m.rb
@@ -83,7 +83,7 @@ module Stytch
       }
       request[:scope] = scopes.join(' ') unless scopes.nil?
 
-      JSON.parse(post_request("/v1/public/#{@project_id}/oauth2/token", request, headers), { symbolize_names: true })
+      post_request("/v1/public/#{@project_id}/oauth2/token", request, headers)
     end
     # ENDMANUAL(M2M::token)
 

--- a/lib/stytch/version.rb
+++ b/lib/stytch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stytch
-  VERSION = '10.3.0'
+  VERSION = '10.3.1'
 end


### PR DESCRIPTION
* When the `post_request` is called, it already  returns parsed JSON. Believed to have been  introduced in `3663ee5cc5d72bbd24e7d3daa34c623f421339ac`

* Bump patch version