### PR TITLE
Add IPGEO to DFP rules endpoint

### DIFF
--- a/lib/stytch/fraud.rb
+++ b/lib/stytch/fraud.rb
@@ -94,37 +94,52 @@ module Stytch
         @connection = connection
       end
 
-      # Set a rule for a particular `visitor_id`, `browser_id`, `visitor_fingerprint`, `browser_fingerprint`, `hardware_fingerprint`, or `network_fingerprint`. This is helpful in cases where you want to allow or block a specific user or fingerprint. You should be careful when setting rules for `browser_fingerprint`, `hardware_fingerprint`, or `network_fingerprint` as they can be shared across multiple users, and you could affect more users than intended.
+      # Set a rule for a particular `visitor_id`, `browser_id`, `visitor_fingerprint`, `browser_fingerprint`, `hardware_fingerprint`, `network_fingerprint`, `cidr_block`, `asn`, or `country_code`. This is helpful in cases where you want to allow or block a specific user or fingerprint. You should be careful when setting rules for `browser_fingerprint`, `hardware_fingerprint`, or `network_fingerprint` as they can be shared across multiple users, and you could affect more users than intended.
+      #
+      # You may not set an `ALLOW` rule for a `country_code`.
       #
       # Rules are applied in the order specified above. For example, if an end user has an `ALLOW` rule set for their `visitor_id` but a `BLOCK` rule set for their `hardware_fingerprint`, they will receive an `ALLOW` verdict because the `visitor_id` rule takes precedence.
       #
+      # If there are conflicts between multiple `cidr_block` rules (for example, if the `ip_address` of the end user overlaps with multiple CIDR blocks that have rules set), the conflicts are resolved as follows:
+      # - The smallest block size takes precedence. For example, if an `ip_address` overlaps with a `cidr_block` rule of `ALLOW` for a block with a prefix of `/32` and a `cidr_block` rule of `BLOCK` with a prefix of `/24`, the rule match verdict will be `ALLOW`.
+      # - Among equivalent size blocks, `BLOCK` takes precedence over `CHALLENGE`, which takes precedence over `ALLOW`. For example, if an `ip_address` overlaps with two `cidr_block` rules with blocks of the same size that return `CHALLENGE` and `ALLOW`, the rule match verdict will be `CHALLENGE`.
+      #
       # == Parameters:
       # action::
-      #   The action that should be returned by a fingerprint lookup for that fingerprint or ID with a `RULE_MATCH` reason. The following values are valid: `ALLOW`, `BLOCK`, `CHALLENGE`, or `NONE`. If a `NONE` action is specified, it will clear the stored rule.
+      #   The action that should be returned by a fingerprint lookup for that identifier with a `RULE_MATCH` reason. The following values are valid: `ALLOW`, `BLOCK`, `CHALLENGE`, or `NONE`. For country codes, `ALLOW` actions are not allowed. If a `NONE` action is specified, it will clear the stored rule.
       #   The type of this field is +RuleAction+ (string enum).
       # visitor_id::
-      #   The visitor ID we want to set a rule for. Only one fingerprint or ID can be specified in the request.
+      #   The visitor ID we want to set a rule for. Only one identifier can be specified in the request.
       #   The type of this field is nilable +String+.
       # browser_id::
-      #   The browser ID we want to set a rule for. Only one fingerprint or ID can be specified in the request.
+      #   The browser ID we want to set a rule for. Only one identifier can be specified in the request.
       #   The type of this field is nilable +String+.
       # visitor_fingerprint::
-      #   The visitor fingerprint we want to set a rule for. Only one fingerprint or ID can be specified in the request.
+      #   The visitor fingerprint we want to set a rule for. Only one identifier can be specified in the request.
       #   The type of this field is nilable +String+.
       # browser_fingerprint::
-      #   The browser fingerprint we want to set a rule for. Only one fingerprint or ID can be specified in the request.
+      #   The browser fingerprint we want to set a rule for. Only one identifier can be specified in the request.
       #   The type of this field is nilable +String+.
       # hardware_fingerprint::
-      #   The hardware fingerprint we want to set a rule for. Only one fingerprint or ID can be specified in the request.
+      #   The hardware fingerprint we want to set a rule for. Only one identifier can be specified in the request.
       #   The type of this field is nilable +String+.
       # network_fingerprint::
-      #   The network fingerprint we want to set a rule for. Only one fingerprint or ID can be specified in the request.
+      #   The network fingerprint we want to set a rule for. Only one identifier can be specified in the request.
       #   The type of this field is nilable +String+.
       # expires_in_minutes::
       #   The number of minutes until this rule expires. If no `expires_in_minutes` is specified, then the rule is kept permanently.
       #   The type of this field is nilable +Integer+.
       # description::
       #   An optional description for the rule.
+      #   The type of this field is nilable +String+.
+      # cidr_block::
+      #   The CIDR block we want to set a rule for. You may pass either an IP address or a CIDR block. The CIDR block prefix must be between 16 and 32, inclusive. If an end user's IP address is within this CIDR block, this rule will be applied. Only one identifier can be specified in the request.
+      #   The type of this field is nilable +String+.
+      # country_code::
+      #   The country code we want to set a rule for. The country code must be a valid ISO 3166-1 alpha-2 code. You may not set `ALLOW` rules for country codes. Only one identifier can be specified in the request.
+      #   The type of this field is nilable +String+.
+      # asn::
+      #   The ASN we want to set a rule for. The ASN must be the string representation of an integer between 0 and 4294967295, inclusive. Only one identifier can be specified in the request.
       #   The type of this field is nilable +String+.
       #
       # == Returns:
@@ -139,25 +154,34 @@ module Stytch
       #   The HTTP status code of the response. Stytch follows standard HTTP response status code patterns, e.g. 2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX are server errors.
       #   The type of this field is +Integer+.
       # visitor_id::
-      #   The cookie stored on the user's device that uniquely identifies them.
+      #   The visitor ID that a rule was set for.
       #   The type of this field is nilable +String+.
       # browser_id::
-      #   Combination of VisitorID and NetworkFingerprint to create a clear identifier of a browser.
+      #   The browser ID that a rule was set for.
       #   The type of this field is nilable +String+.
       # visitor_fingerprint::
-      #   Cookie-less way of identifying a unique user.
+      #   The visitor fingerprint that a rule was set for.
       #   The type of this field is nilable +String+.
       # browser_fingerprint::
-      #   Combination of signals to identify a browser and its specific version.
+      #   The browser fingerprint that a rule was set for.
       #   The type of this field is nilable +String+.
       # hardware_fingerprint::
-      #   Combinations of signals to identify an operating system and architecture.
+      #   The hardware fingerprint that a rule was set for.
       #   The type of this field is nilable +String+.
       # network_fingerprint::
-      #   Combination of signals associated with a specific network commonly known as TLS fingerprinting.
+      #   The network fingerprint that a rule was set for.
       #   The type of this field is nilable +String+.
       # expires_at::
       #   The timestamp when the rule expires. Values conform to the RFC 3339 standard and are expressed in UTC, e.g. `2021-12-29T12:33:09Z`.
+      #   The type of this field is nilable +String+.
+      # cidr_block::
+      #   The CIDR block that a rule was set for. If an end user's IP address is within this CIDR block, this rule will be applied.
+      #   The type of this field is nilable +String+.
+      # country_code::
+      #   The country code that a rule was set for.
+      #   The type of this field is nilable +String+.
+      # asn::
+      #   The ASN that a rule was set for.
       #   The type of this field is nilable +String+.
       def set(
         action:,
@@ -168,7 +192,10 @@ module Stytch
         hardware_fingerprint: nil,
         network_fingerprint: nil,
         expires_in_minutes: nil,
-        description: nil
+        description: nil,
+        cidr_block: nil,
+        country_code: nil,
+        asn: nil
       )
         headers = {}
         request = {
@@ -182,6 +209,9 @@ module Stytch
         request[:network_fingerprint] = network_fingerprint unless network_fingerprint.nil?
         request[:expires_in_minutes] = expires_in_minutes unless expires_in_minutes.nil?
         request[:description] = description unless description.nil?
+        request[:cidr_block] = cidr_block unless cidr_block.nil?
+        request[:country_code] = country_code unless country_code.nil?
+        request[:asn] = asn unless asn.nil?
 
         post_request('/v1/rules/set', request, headers)
       end

--- a/lib/stytch/version.rb
+++ b/lib/stytch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stytch
-  VERSION = '10.6.0'
+  VERSION = '10.7.0'
 end


### PR DESCRIPTION
This PR adds support for IPGEO in the fraud rules endpoint. You can now set rules on CIDR blocks, ASNs, and country codes. The fingerprint lookup endpoint will now also return information on which rule type and identifier were applied, if a `RULE_MATCH` reason was returned.