### PR TITLE
Accept BaseURL as Issuer

### DIFF
--- a/lib/stytch/b2b_sessions.rb
+++ b/lib/stytch/b2b_sessions.rb
@@ -582,10 +582,13 @@ module StytchB2B
       max_token_age_seconds = 300 if max_token_age_seconds.nil?
       clock_tolerance_seconds = 0 if clock_tolerance_seconds.nil?
 
-      issuer = 'stytch.com/' + @project_id
+      default_issuer = 'stytch.com/' + @project_id
+      base_url_issuer = @connection.api_host
+      valid_issuers = [default_issuer, base_url_issuer]
+      
       begin
         decoded_token = JWT.decode session_jwt, nil, true,
-                                   { jwks: @jwks_loader, iss: issuer, verify_iss: true, aud: @project_id, verify_aud: true, algorithms: ['RS256'], nbf_leeway: clock_tolerance_seconds }
+                                { jwks: @jwks_loader, iss: valid_issuers, verify_iss: true, aud: @project_id, verify_aud: true, algorithms: ['RS256'], nbf_leeway: clock_tolerance_seconds }
 
         session = decoded_token[0]
         iat_time = Time.at(session['iat']).to_datetime

--- a/lib/stytch/b2b_sessions.rb
+++ b/lib/stytch/b2b_sessions.rb
@@ -585,10 +585,10 @@ module StytchB2B
       default_issuer = 'stytch.com/' + @project_id
       base_url_issuer = @connection.api_host
       valid_issuers = [default_issuer, base_url_issuer]
-      
+
       begin
         decoded_token = JWT.decode session_jwt, nil, true,
-                                { jwks: @jwks_loader, iss: valid_issuers, verify_iss: true, aud: @project_id, verify_aud: true, algorithms: ['RS256'], nbf_leeway: clock_tolerance_seconds }
+                                   { jwks: @jwks_loader, iss: valid_issuers, verify_iss: true, aud: @project_id, verify_aud: true, algorithms: ['RS256'], nbf_leeway: clock_tolerance_seconds }
 
         session = decoded_token[0]
         iat_time = Time.at(session['iat']).to_datetime

--- a/lib/stytch/m2m.rb
+++ b/lib/stytch/m2m.rb
@@ -187,7 +187,7 @@ module Stytch
       default_issuer = 'stytch.com/' + @project_id
       base_url_issuer = @connection.api_host
       valid_issuers = [default_issuer, base_url_issuer]
-      
+
       begin
         decoded_token = JWT.decode jwt, nil, true,
                                    { jwks: @jwks_loader, iss: valid_issuers, verify_iss: true, aud: @project_id, verify_aud: true, algorithms: ['RS256'], nbf_leeway: clock_tolerance_seconds }

--- a/lib/stytch/m2m.rb
+++ b/lib/stytch/m2m.rb
@@ -184,10 +184,13 @@ module Stytch
     # If clock_tolerance_seconds is not supplied 0 seconds will be used as the default.
     def authenticate_token_local(jwt, clock_tolerance_seconds: nil)
       clock_tolerance_seconds = 0 if clock_tolerance_seconds.nil?
-      issuer = 'stytch.com/' + @project_id
+      default_issuer = 'stytch.com/' + @project_id
+      base_url_issuer = @connection.api_host
+      valid_issuers = [default_issuer, base_url_issuer]
+      
       begin
         decoded_token = JWT.decode jwt, nil, true,
-                                   { jwks: @jwks_loader, iss: issuer, verify_iss: true, aud: @project_id, verify_aud: true, algorithms: ['RS256'], nbf_leeway: clock_tolerance_seconds }
+                                   { jwks: @jwks_loader, iss: valid_issuers, verify_iss: true, aud: @project_id, verify_aud: true, algorithms: ['RS256'], nbf_leeway: clock_tolerance_seconds }
         decoded_token[0]
       rescue JWT::InvalidIssuerError
         raise JWTInvalidIssuerError

--- a/lib/stytch/sessions.rb
+++ b/lib/stytch/sessions.rb
@@ -384,10 +384,13 @@ module Stytch
       max_token_age_seconds = 300 if max_token_age_seconds.nil?
       clock_tolerance_seconds = 0 if clock_tolerance_seconds.nil?
 
-      issuer = 'stytch.com/' + @project_id
+      default_issuer = 'stytch.com/' + @project_id
+      base_url_issuer = @connection.api_host
+      valid_issuers = [default_issuer, base_url_issuer]
+
       begin
         decoded_token = JWT.decode session_jwt, nil, true,
-                                   { jwks: @jwks_loader, iss: issuer, verify_iss: true, aud: @project_id, verify_aud: true, algorithms: ['RS256'], nbf_leeway: clock_tolerance_seconds }
+                                   { jwks: @jwks_loader, iss: valid_issuers, verify_iss: true, aud: @project_id, verify_aud: true, algorithms: ['RS256'], nbf_leeway: clock_tolerance_seconds }
 
         session = decoded_token[0]
         iat_time = Time.at(session['iat']).to_datetime

--- a/lib/stytch/version.rb
+++ b/lib/stytch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stytch
-  VERSION = '10.16.0'
+  VERSION = '10.17.0'
 end

--- a/spec/stytch/sessions_spec.rb
+++ b/spec/stytch/sessions_spec.rb
@@ -3,7 +3,7 @@
 # Simple connection class for testing
 class TestConnection
   attr_reader :api_host
-  
+
   def initialize(api_host = 'https://test.stytch.com')
     @api_host = api_host
   end
@@ -65,7 +65,7 @@ RSpec.describe Stytch::Sessions do
   it 'correctly decodes a JWT with custom issuer' do
     project_id = 'project-test-00000000-0000-0000-0000-000000000000'
     custom_api_host = 'https://api.custom-domain.com'
-    
+
     # Use the TestConnection class with custom api_host
     connection = TestConnection.new(custom_api_host)
     sessions = Stytch::Sessions.new(connection, project_id)
@@ -117,7 +117,7 @@ RSpec.describe Stytch::Sessions do
 
   it 'marshals JWT into session (new format)' do
     project_id = 'project-test-00000000-0000-0000-0000-000000000000'
-    
+
     # Use the TestConnection class with default api_host
     connection = TestConnection.new
     sessions = Stytch::Sessions.new(connection, project_id)
@@ -132,7 +132,7 @@ RSpec.describe Stytch::Sessions do
 
   it 'marshals JWT into session (old format)' do
     project_id = 'project-test-00000000-0000-0000-0000-000000000000'
-    
+
     # Use the TestConnection class with default api_host
     connection = TestConnection.new
     sessions = Stytch::Sessions.new(connection, project_id)

--- a/spec/stytch/sessions_spec.rb
+++ b/spec/stytch/sessions_spec.rb
@@ -1,9 +1,21 @@
 # frozen_string_literal: true
 
+# Simple connection class for testing
+class TestConnection
+  attr_reader :api_host
+  
+  def initialize(api_host = 'https://test.stytch.com')
+    @api_host = api_host
+  end
+end
+
 RSpec.describe Stytch::Sessions do
   it 'correctly decodes a JWT' do
     project_id = 'project-test-00000000-0000-0000-0000-000000000000'
-    sessions = Stytch::Sessions.new(nil, project_id) # the methods we're calling don't require a connection
+
+    # Use the TestConnection class with default api_host
+    connection = TestConnection.new
+    sessions = Stytch::Sessions.new(connection, project_id)
 
     kid = 'jwk-test-00000000-0000-0000-0000-000000000000'
     headers = { kid: kid }
@@ -50,9 +62,65 @@ RSpec.describe Stytch::Sessions do
     expect(sessions.authenticate_jwt_local(token)).to eq(expected)
   end
 
+  it 'correctly decodes a JWT with custom issuer' do
+    project_id = 'project-test-00000000-0000-0000-0000-000000000000'
+    custom_api_host = 'https://api.custom-domain.com'
+    
+    # Use the TestConnection class with custom api_host
+    connection = TestConnection.new(custom_api_host)
+    sessions = Stytch::Sessions.new(connection, project_id)
+
+    kid = 'jwk-test-00000000-0000-0000-0000-000000000000'
+    headers = { kid: kid }
+
+    now = Time.now
+    now_timestamp = format_timestamp(now)
+    claims = {
+      'https://stytch.com/session' => {
+        'started_at' => now_timestamp,
+        'last_accessed_at' => now_timestamp,
+        'expires_at' => (now + 3600).to_datetime.iso8601,
+        'attributes' => { 'user_agent' => '', 'ip_address' => '' },
+        'authentication_factors' => [
+          {
+            'delivery_method' => 'email',
+            'email_factor' => {
+              'email_address' => 'sandbox@stytch.com',
+              'email_id' => 'email-live-cca9d7d0-11b6-4167-9385-d7e0c9a77418'
+            },
+            'last_authenticated_at' => now_timestamp,
+            'type' => 'magic_link'
+          }
+        ],
+        'id' => 'session-live-e26a0ccb-0dc0-4edb-a4bb-e70210f43555'
+      },
+      'sub' => 'user-live-fde03dd1-fff7-4b3c-9b31-ead3fbc224de',
+      'iat' => now.to_i,
+      'nbf' => now.to_i,
+      'exp' => now.to_i + 5 * 60, # five minutes
+      'iss' => custom_api_host, # Using the custom domain as issuer
+      'aud' => [project_id]
+    }
+    jwk = JWT::JWK.new(OpenSSL::PKey::RSA.new(2048), kid)
+    token = JWT.encode(claims, jwk.keypair, 'RS256', headers)
+
+    # patch the jwks_loader method so that it uses the JWK we just created
+    # instead of calling the API directly
+    patch_jwks_loader = lambda do |_options|
+      { 'keys' => [jwk.export] }
+    end
+    sessions.instance_variable_set(:@jwks_loader, patch_jwks_loader)
+    expected = sessions.marshal_jwt_into_session(claims)
+
+    expect(sessions.authenticate_jwt_local(token)).to eq(expected)
+  end
+
   it 'marshals JWT into session (new format)' do
     project_id = 'project-test-00000000-0000-0000-0000-000000000000'
-    sessions = Stytch::Sessions.new(nil, project_id) # the methods we're calling don't require a connection
+    
+    # Use the TestConnection class with default api_host
+    connection = TestConnection.new
+    sessions = Stytch::Sessions.new(connection, project_id)
 
     now = Time.utc(2022, 5, 3, 18, 51, 41)
     claims = jwt_claims(project_id, now)
@@ -64,7 +132,10 @@ RSpec.describe Stytch::Sessions do
 
   it 'marshals JWT into session (old format)' do
     project_id = 'project-test-00000000-0000-0000-0000-000000000000'
-    sessions = Stytch::Sessions.new(nil, project_id) # the methods we're calling don't require a connection
+    
+    # Use the TestConnection class with default api_host
+    connection = TestConnection.new
+    sessions = Stytch::Sessions.new(connection, project_id)
 
     now = Time.utc(2022, 5, 3, 18, 51, 41)
     claims = jwt_claims(project_id, now)


### PR DESCRIPTION
When using custom base URLs to call our API we return a different issuer. This is to be compliant with OIDC JWTs. We should accept these for our local validation!