### PR TITLE
[STYTCH-2][AUTH-5999] Local authorization manual methods for custom org roles.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,4 +19,6 @@ Style/StringConcatenation: { Enabled: false }
 
 RSpec/DescribedClass: { Enabled: false }
 RSpec/ExampleLength: { Enabled: false }
+RSpec/InstanceVariable: { Enabled: false }
 RSpec/MultipleExpectations: { Enabled: false }
+RSpec/MultipleMemoizedHelpers: { Enabled: false }

--- a/lib/stytch/rbac_local.rb
+++ b/lib/stytch/rbac_local.rb
@@ -115,12 +115,12 @@ module Stytch
       resource_id = authorization_check['resource_id']
 
       # Check if any of the token scopes grant permission for this action/resource
-      policy['scopes'].each { |scope_obj|
+      policy['scopes'].each do |scope_obj|
         scope_name = scope_obj['scope']
         next unless token_scopes.include?(scope_name)
 
         # Check if this scope grants permission for the requested action/resource
-        scope_obj['permissions'].each { |permission|
+        scope_obj['permissions'].each do |permission|
           actions = permission['actions']
           resource = permission['resource_id']
           has_matching_action = actions.include?('*') || actions.include?(action)
@@ -128,8 +128,8 @@ module Stytch
           if has_matching_action && has_matching_resource
             return # Permission granted
           end
-        }
-      }
+        end
+      end
 
       # If we get here, we didn't find a matching permission
       raise Stytch::PermissionError, authorization_check

--- a/lib/stytch/rbac_local.rb
+++ b/lib/stytch/rbac_local.rb
@@ -9,6 +9,10 @@ module Stytch
       @rbac_client = rbac_client
       @policy_last_update = 0
       @cached_policy = nil
+      @cached_org_policies = {}
+      # TTL, in seconds, before a cached policy is considered stale
+      # and should be refreshed. Amounts to 5 minutes.
+      @cache_ttl = 300
     end
 
     def reload_policy
@@ -16,9 +20,25 @@ module Stytch
       @policy_last_update = Time.now.to_i
     end
 
+    def reload_org_policy(organization_id:)
+      @cached_org_policies[organization_id] = CachedOrgPolicy.new(
+        org_policy: @rbac_client.organizations.get_org_policy(organization_id: organization_id)
+      )
+    end
+
     def get_policy(invalidate: false)
-      reload_policy if invalidate || @cached_policy.nil? || @policy_last_update < Time.now.to_i - 300
+      reload_policy if invalidate || @cached_policy.nil? || @policy_last_update < Time.now.to_i - @cache_ttl
       @cached_policy
+    end
+
+    def get_org_policy(organization_id:, invalidate: false)
+      is_missing = @cached_org_policies[organization_id].nil?
+      is_stale = !is_missing && @cached_org_policies[organization_id].last_update < Time.now.to_i - @cache_ttl
+      reload_org_policy(organization_id: organization_id) if invalidate || is_missing || is_stale
+
+      return { 'roles' => [] } if @cached_org_policies[organization_id].nil?
+
+      @cached_org_policies[organization_id].org_policy
     end
 
     # Performs an authorization check against the project's policy and a set of roles. If the
@@ -34,19 +54,18 @@ module Stytch
       raise Stytch::TenancyError.new(subject_org_id, authorization_check['organization_id']) if subject_org_id != authorization_check['organization_id']
 
       policy = get_policy
+      org_policy = get_org_policy(organization_id: subject_org_id)
+      all_roles = policy['roles'].concat(org_policy['roles'])
 
-      for role in policy['roles']
+      return if all_roles.any? do |role|
         next unless subject_roles.include?(role['role_id'])
 
-        for permission in role['permissions']
+        role['permissions'].any? do |permission|
           actions = permission['actions']
           resource = permission['resource_id']
           has_matching_action = actions.include?('*') || actions.include?(authorization_check['action'])
           has_matching_resource = resource == authorization_check['resource_id']
-          if has_matching_action && has_matching_resource
-            # All good
-            return
-          end
+          has_matching_action && has_matching_resource
         end
       end
 
@@ -64,17 +83,15 @@ module Stytch
       policy = get_policy
 
       # For consumer authorization, we check roles without tenancy validation
-      for role in policy['roles']
+      return if policy['roles'].any? do |role|
         next unless subject_roles.include?(role['role_id'])
 
-        for permission in role['permissions']
+        role['permissions'].any? do |permission|
           actions = permission['actions']
           resource = permission['resource_id']
           has_matching_action = actions.include?('*') || actions.include?(authorization_check['action'])
           has_matching_resource = resource == authorization_check['resource_id']
-          if has_matching_action && has_matching_resource
-            return # Permission granted
-          end
+          has_matching_action && has_matching_resource
         end
       end
 
@@ -98,12 +115,12 @@ module Stytch
       resource_id = authorization_check['resource_id']
 
       # Check if any of the token scopes grant permission for this action/resource
-      for scope_obj in policy['scopes']
+      policy['scopes'].each { |scope_obj|
         scope_name = scope_obj['scope']
         next unless token_scopes.include?(scope_name)
 
         # Check if this scope grants permission for the requested action/resource
-        for permission in scope_obj['permissions']
+        scope_obj['permissions'].each { |permission|
           actions = permission['actions']
           resource = permission['resource_id']
           has_matching_action = actions.include?('*') || actions.include?(action)
@@ -111,11 +128,20 @@ module Stytch
           if has_matching_action && has_matching_resource
             return # Permission granted
           end
-        end
-      end
+        }
+      }
 
       # If we get here, we didn't find a matching permission
       raise Stytch::PermissionError, authorization_check
     end
+  end
+
+  class CachedOrgPolicy
+    def initialize(org_policy:)
+      @org_policy = org_policy['org_policy']
+      @last_update = Time.now.to_i
+    end
+
+    attr_reader :org_policy, :last_update
   end
 end

--- a/lib/stytch/rbac_local.rb
+++ b/lib/stytch/rbac_local.rb
@@ -115,19 +115,17 @@ module Stytch
       resource_id = authorization_check['resource_id']
 
       # Check if any of the token scopes grant permission for this action/resource
-      policy['scopes'].each do |scope_obj|
+      return if policy['scopes'].any? do |scope_obj|
         scope_name = scope_obj['scope']
         next unless token_scopes.include?(scope_name)
 
         # Check if this scope grants permission for the requested action/resource
-        scope_obj['permissions'].each do |permission|
+        scope_obj['permissions'].any? do |permission|
           actions = permission['actions']
           resource = permission['resource_id']
           has_matching_action = actions.include?('*') || actions.include?(action)
           has_matching_resource = resource == resource_id
-          if has_matching_action && has_matching_resource
-            return # Permission granted
-          end
+          has_matching_action && has_matching_resource
         end
       end
 

--- a/lib/stytch/version.rb
+++ b/lib/stytch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stytch
-  VERSION = '10.41.0'
+  VERSION = '10.42.0'
 end

--- a/spec/stytch/b2b_idp_spec.rb
+++ b/spec/stytch/b2b_idp_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/MultipleMemoizedHelpers
-
 require 'spec_helper'
 require 'jwt'
 
@@ -271,5 +269,3 @@ RSpec.describe StytchB2B::IDP do
     end
   end
 end
-
-# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/stytch/rbac_local_spec.rb
+++ b/spec/stytch/rbac_local_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe Stytch::PolicyCache do
-  let(:mock_rbac_client) { instance_double('rbac_client') }
+  let(:mock_organizations) { instance_double('Organizations') }
+  let(:mock_rbac_client) { instance_double('rbac_client', organizations: mock_organizations) }
+
   let(:policy_cache) { described_class.new(rbac_client: mock_rbac_client) }
 
   let(:sample_policy) do
@@ -33,8 +35,34 @@ RSpec.describe Stytch::PolicyCache do
     }
   end
 
+  let(:sample_org_policy) do
+    {
+      'roles' => [
+        {
+          'role_id' => 'resident',
+          'permissions' => [
+            {
+              'resource_id' => 'fridge',
+              'actions' => ['*'],
+            }
+          ]
+        },
+        {
+          'role_id' => 'shopper',
+          'permissions' => [
+            {
+              'resource_id' => 'fridge',
+              'actions' => ['stock'],
+            }
+          ]
+        }
+      ]
+    }
+  end
+
   before do
     allow(mock_rbac_client).to receive(:policy).and_return({ 'policy' => sample_policy })
+    allow(mock_organizations).to receive(:get_org_policy).and_return('org_policy' => sample_org_policy)
   end
 
   describe '#initialize' do
@@ -42,6 +70,7 @@ RSpec.describe Stytch::PolicyCache do
       expect(policy_cache.instance_variable_get(:@rbac_client)).to eq(mock_rbac_client)
       expect(policy_cache.instance_variable_get(:@policy_last_update)).to eq(0)
       expect(policy_cache.instance_variable_get(:@cached_policy)).to be_nil
+      expect(policy_cache.instance_variable_get(:@cached_org_policies)).to eq({})
     end
   end
 
@@ -50,6 +79,16 @@ RSpec.describe Stytch::PolicyCache do
       policy_cache.reload_policy
       expect(policy_cache.instance_variable_get(:@cached_policy)).to eq(sample_policy)
       expect(policy_cache.instance_variable_get(:@policy_last_update)).to be > 0
+    end
+  end
+
+  describe '#reload_org_policy' do
+    it 'reloads org policy from rbac_client' do
+      policy_cache.reload_org_policy(organization_id: 'org-123')
+
+      cache = policy_cache.instance_variable_get(:@cached_org_policies)
+      cached_org_policy = cache['org-123'].instance_variable_get(:@org_policy)
+      expect(cached_org_policy).to eq(sample_org_policy)
     end
   end
 
@@ -93,6 +132,67 @@ RSpec.describe Stytch::PolicyCache do
       it 'reloads policy' do
         result = policy_cache.get_policy(invalidate: true)
         expect(result).to eq(sample_policy)
+      end
+    end
+  end
+
+  describe '#get_org_policy' do
+    before(:all) do
+      @org_id = 'org-123'
+    end
+
+    context 'when cache is empty' do
+      it 'reloads org policy' do
+        result = policy_cache.get_org_policy(organization_id: @org_id)
+        expect(result).to eq(sample_org_policy)
+      end
+    end
+
+    context 'when cache is stale' do
+      before do
+        cached_org_policy = Stytch::CachedOrgPolicy.new(org_policy: sample_org_policy)
+        # Clear the Org policy roles so we can ensure it gets properly refreshed.
+        cached_org_policy.instance_variable_set(:@org_policy, { 'roles' => [] })
+        cached_org_policy.instance_variable_set(:@last_update, Time.now.to_i - 400)
+
+        policy_cache.instance_variable_set(:@cached_org_policies, {
+          @org_id.to_s => cached_org_policy
+        })
+      end
+
+      it 'reloads policy' do
+        result = policy_cache.get_org_policy(organization_id: @org_id)
+        expect(result).to eq(sample_org_policy)
+      end
+    end
+
+    context 'when cache is fresh' do
+      before do
+        cached_org_policy = Stytch::CachedOrgPolicy.new(org_policy: { 'org_policy' => 'policy' })
+        cached_org_policy.instance_variable_set(:@last_update, Time.now.to_i - 100)
+        policy_cache.instance_variable_set(:@cached_org_policies, {
+          @org_id.to_s => cached_org_policy
+        })
+      end
+
+      it 'returns cached policy' do
+        result = policy_cache.get_org_policy(organization_id: @org_id)
+        expect(result).to eq('policy')
+      end
+    end
+
+    context 'when invalidate is true' do
+      before do
+        cached_org_policy = Stytch::CachedOrgPolicy.new(org_policy: { 'org_policy' => 'policy' })
+        cached_org_policy.instance_variable_set(:@last_update, Time.now.to_i - 100)
+        policy_cache.instance_variable_set(:@cached_org_policies, {
+          @org_id.to_s => cached_org_policy
+        })
+      end
+
+      it 'reloads policy' do
+        result = policy_cache.get_org_policy(organization_id: @org_id, invalidate: true)
+        expect(result).to eq(sample_org_policy)
       end
     end
   end
@@ -147,10 +247,10 @@ RSpec.describe Stytch::PolicyCache do
     it 'succeeds for specific action when user has matching role and permission' do
       expect do
         policy_cache.perform_authorization_check(
-          subject_roles: ['user'],
+          subject_roles: ['shopper'],
           authorization_check: {
-            'action' => 'read',
-            'resource_id' => 'users',
+            'action' => 'stock',
+            'resource_id' => 'fridge',
             'organization_id' => 'org-123'
           },
           subject_org_id: 'org-123'
@@ -175,7 +275,7 @@ RSpec.describe Stytch::PolicyCache do
     it 'succeeds if any role has permission when user has multiple roles' do
       expect do
         policy_cache.perform_authorization_check(
-          subject_roles: %w[guest user],
+          subject_roles: %w[guest user resident],
           authorization_check: {
             'action' => 'write',
             'resource_id' => 'posts',

--- a/spec/stytch/rbac_local_spec.rb
+++ b/spec/stytch/rbac_local_spec.rb
@@ -136,14 +136,13 @@ RSpec.describe Stytch::PolicyCache do
     end
   end
 
+  # rubocop:disable RSpec/MultipleMemoizedHelpers
   describe '#get_org_policy' do
-    before(:all) do
-      @org_id = 'org-123'
-    end
+    let(:org_id) { 'org-123' }
 
     context 'when cache is empty' do
       it 'reloads org policy' do
-        result = policy_cache.get_org_policy(organization_id: @org_id)
+        result = policy_cache.get_org_policy(organization_id: org_id)
         expect(result).to eq(sample_org_policy)
       end
     end
@@ -156,12 +155,12 @@ RSpec.describe Stytch::PolicyCache do
         cached_org_policy.instance_variable_set(:@last_update, Time.now.to_i - 400)
 
         policy_cache.instance_variable_set(:@cached_org_policies, {
-                                             @org_id.to_s => cached_org_policy
+                                             org_id.to_s => cached_org_policy
                                            })
       end
 
       it 'reloads policy' do
-        result = policy_cache.get_org_policy(organization_id: @org_id)
+        result = policy_cache.get_org_policy(organization_id: org_id)
         expect(result).to eq(sample_org_policy)
       end
     end
@@ -171,12 +170,12 @@ RSpec.describe Stytch::PolicyCache do
         cached_org_policy = Stytch::CachedOrgPolicy.new(org_policy: { 'org_policy' => 'policy' })
         cached_org_policy.instance_variable_set(:@last_update, Time.now.to_i - 100)
         policy_cache.instance_variable_set(:@cached_org_policies, {
-                                             @org_id.to_s => cached_org_policy
+                                             org_id.to_s => cached_org_policy
                                            })
       end
 
       it 'returns cached policy' do
-        result = policy_cache.get_org_policy(organization_id: @org_id)
+        result = policy_cache.get_org_policy(organization_id: org_id)
         expect(result).to eq('policy')
       end
     end
@@ -186,17 +185,19 @@ RSpec.describe Stytch::PolicyCache do
         cached_org_policy = Stytch::CachedOrgPolicy.new(org_policy: { 'org_policy' => 'policy' })
         cached_org_policy.instance_variable_set(:@last_update, Time.now.to_i - 100)
         policy_cache.instance_variable_set(:@cached_org_policies, {
-                                             @org_id.to_s => cached_org_policy
+                                             org_id.to_s => cached_org_policy
                                            })
       end
 
       it 'reloads policy' do
-        result = policy_cache.get_org_policy(organization_id: @org_id, invalidate: true)
+        result = policy_cache.get_org_policy(organization_id: org_id, invalidate: true)
         expect(result).to eq(sample_org_policy)
       end
     end
   end
+  # rubocop:enable RSpec/MultipleMemoizedHelpers
 
+  # rubocop:disable RSpec/MultipleMemoizedHelpers
   describe '#perform_authorization_check' do
     let(:authorization_check) do
       {
@@ -286,7 +287,9 @@ RSpec.describe Stytch::PolicyCache do
       end.not_to raise_error
     end
   end
+  # rubocop:enable RSpec/MultipleMemoizedHelpers
 
+  # rubocop:disable RSpec/MultipleMemoizedHelpers
   describe '#perform_consumer_authorization_check' do
     let(:authorization_check) do
       {
@@ -352,4 +355,5 @@ RSpec.describe Stytch::PolicyCache do
       end.not_to raise_error
     end
   end
+  # rubocop:enable RSpec/MultipleMemoizedHelpers
 end

--- a/spec/stytch/rbac_local_spec.rb
+++ b/spec/stytch/rbac_local_spec.rb
@@ -136,7 +136,6 @@ RSpec.describe Stytch::PolicyCache do
     end
   end
 
-  # rubocop:disable RSpec/MultipleMemoizedHelpers
   describe '#get_org_policy' do
     let(:org_id) { 'org-123' }
 
@@ -195,9 +194,7 @@ RSpec.describe Stytch::PolicyCache do
       end
     end
   end
-  # rubocop:enable RSpec/MultipleMemoizedHelpers
 
-  # rubocop:disable RSpec/MultipleMemoizedHelpers
   describe '#perform_authorization_check' do
     let(:authorization_check) do
       {
@@ -287,9 +284,7 @@ RSpec.describe Stytch::PolicyCache do
       end.not_to raise_error
     end
   end
-  # rubocop:enable RSpec/MultipleMemoizedHelpers
 
-  # rubocop:disable RSpec/MultipleMemoizedHelpers
   describe '#perform_consumer_authorization_check' do
     let(:authorization_check) do
       {
@@ -355,5 +350,4 @@ RSpec.describe Stytch::PolicyCache do
       end.not_to raise_error
     end
   end
-  # rubocop:enable RSpec/MultipleMemoizedHelpers
 end

--- a/spec/stytch/rbac_local_spec.rb
+++ b/spec/stytch/rbac_local_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Stytch::PolicyCache do
           'permissions' => [
             {
               'resource_id' => 'fridge',
-              'actions' => ['*'],
+              'actions' => ['*']
             }
           ]
         },
@@ -52,7 +52,7 @@ RSpec.describe Stytch::PolicyCache do
           'permissions' => [
             {
               'resource_id' => 'fridge',
-              'actions' => ['stock'],
+              'actions' => ['stock']
             }
           ]
         }
@@ -156,8 +156,8 @@ RSpec.describe Stytch::PolicyCache do
         cached_org_policy.instance_variable_set(:@last_update, Time.now.to_i - 400)
 
         policy_cache.instance_variable_set(:@cached_org_policies, {
-          @org_id.to_s => cached_org_policy
-        })
+                                             @org_id.to_s => cached_org_policy
+                                           })
       end
 
       it 'reloads policy' do
@@ -171,8 +171,8 @@ RSpec.describe Stytch::PolicyCache do
         cached_org_policy = Stytch::CachedOrgPolicy.new(org_policy: { 'org_policy' => 'policy' })
         cached_org_policy.instance_variable_set(:@last_update, Time.now.to_i - 100)
         policy_cache.instance_variable_set(:@cached_org_policies, {
-          @org_id.to_s => cached_org_policy
-        })
+                                             @org_id.to_s => cached_org_policy
+                                           })
       end
 
       it 'returns cached policy' do
@@ -186,8 +186,8 @@ RSpec.describe Stytch::PolicyCache do
         cached_org_policy = Stytch::CachedOrgPolicy.new(org_policy: { 'org_policy' => 'policy' })
         cached_org_policy.instance_variable_set(:@last_update, Time.now.to_i - 100)
         policy_cache.instance_variable_set(:@cached_org_policies, {
-          @org_id.to_s => cached_org_policy
-        })
+                                             @org_id.to_s => cached_org_policy
+                                           })
       end
 
       it 'reloads policy' do


### PR DESCRIPTION
# Description

- Adds local authorization methods for handling Custom Org Roles.
- Part of AUTH-5999, STYTCH-2.