### PR TITLE
Minor updates

### DIFF
--- a/lib/stytch/b2b_discovery.rb
+++ b/lib/stytch/b2b_discovery.rb
@@ -123,6 +123,9 @@ module StytchB2B
       # member_device::
       #   If a valid `telemetry_id` was passed in the request and the [Fingerprint Lookup API](https://stytch.com/docs/fraud/api/fingerprint-lookup) returned results, the `member_device` response field will contain information about the member's device attributes.
       #   The type of this field is nilable +DeviceInfo+ (+object+).
+      # intermediate_session_token_expires_at::
+      #   (no documentation yet)
+      #   The type of this field is nilable +String+.
       def exchange(
         intermediate_session_token:,
         organization_id:,
@@ -361,6 +364,9 @@ module StytchB2B
       # member_device::
       #   If a valid `telemetry_id` was passed in the request and the [Fingerprint Lookup API](https://stytch.com/docs/fraud/api/fingerprint-lookup) returned results, the `member_device` response field will contain information about the member's device attributes.
       #   The type of this field is nilable +DeviceInfo+ (+object+).
+      # intermediate_session_token_expires_at::
+      #   (no documentation yet)
+      #   The type of this field is nilable +String+.
       def create(
         intermediate_session_token:,
         session_duration_minutes: nil,

--- a/lib/stytch/b2b_impersonation.rb
+++ b/lib/stytch/b2b_impersonation.rb
@@ -64,6 +64,9 @@ module StytchB2B
     # mfa_required::
     #   MFA will not be required when authenticating impersonation tokens.
     #   The type of this field is nilable +MfaRequired+ (+object+).
+    # intermediate_session_token_expires_at::
+    #   (no documentation yet)
+    #   The type of this field is nilable +String+.
     def authenticate(
       impersonation_token:
     )

--- a/lib/stytch/b2b_magic_links.rb
+++ b/lib/stytch/b2b_magic_links.rb
@@ -133,6 +133,9 @@ module StytchB2B
     # member_device::
     #   If a valid `telemetry_id` was passed in the request and the [Fingerprint Lookup API](https://stytch.com/docs/fraud/api/fingerprint-lookup) returned results, the `member_device` response field will contain information about the member's device attributes.
     #   The type of this field is nilable +DeviceInfo+ (+object+).
+    # intermediate_session_token_expires_at::
+    #   (no documentation yet)
+    #   The type of this field is nilable +String+.
     def authenticate(
       magic_links_token:,
       pkce_code_verifier: nil,
@@ -502,6 +505,9 @@ module StytchB2B
       # status_code::
       #   The HTTP status code of the response. Stytch follows standard HTTP response status code patterns, e.g. 2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX are server errors.
       #   The type of this field is +Integer+.
+      # intermediate_session_token_expires_at::
+      #   (no documentation yet)
+      #   The type of this field is nilable +String+.
       def authenticate(
         discovery_magic_links_token:,
         pkce_code_verifier: nil

--- a/lib/stytch/b2b_oauth.rb
+++ b/lib/stytch/b2b_oauth.rb
@@ -139,6 +139,9 @@ module StytchB2B
     # member_device::
     #   If a valid `telemetry_id` was passed in the request and the [Fingerprint Lookup API](https://stytch.com/docs/fraud/api/fingerprint-lookup) returned results, the `member_device` response field will contain information about the member's device attributes.
     #   The type of this field is nilable +DeviceInfo+ (+object+).
+    # intermediate_session_token_expires_at::
+    #   (no documentation yet)
+    #   The type of this field is nilable +String+.
     def authenticate(
       oauth_token:,
       session_token: nil,
@@ -236,6 +239,9 @@ module StytchB2B
       # status_code::
       #   The HTTP status code of the response. Stytch follows standard HTTP response status code patterns, e.g. 2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX are server errors.
       #   The type of this field is +Integer+.
+      # intermediate_session_token_expires_at::
+      #   (no documentation yet)
+      #   The type of this field is nilable +String+.
       def authenticate(
         discovery_oauth_token:,
         session_token: nil,

--- a/lib/stytch/b2b_otp.rb
+++ b/lib/stytch/b2b_otp.rb
@@ -442,6 +442,9 @@ module StytchB2B
       # member_device::
       #   If a valid `telemetry_id` was passed in the request and the [Fingerprint Lookup API](https://stytch.com/docs/fraud/api/fingerprint-lookup) returned results, the `member_device` response field will contain information about the member's device attributes.
       #   The type of this field is nilable +DeviceInfo+ (+object+).
+      # intermediate_session_token_expires_at::
+      #   (no documentation yet)
+      #   The type of this field is nilable +String+.
       def authenticate(
         organization_id:,
         email_address:,
@@ -562,6 +565,9 @@ module StytchB2B
         # status_code::
         #   The HTTP status code of the response. Stytch follows standard HTTP response status code patterns, e.g. 2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX are server errors.
         #   The type of this field is +Integer+.
+        # intermediate_session_token_expires_at::
+        #   (no documentation yet)
+        #   The type of this field is nilable +String+.
         def authenticate(
           email_address:,
           code:

--- a/lib/stytch/b2b_passwords.rb
+++ b/lib/stytch/b2b_passwords.rb
@@ -341,6 +341,9 @@ module StytchB2B
     # member_device::
     #   If a valid `telemetry_id` was passed in the request and the [Fingerprint Lookup API](https://stytch.com/docs/fraud/api/fingerprint-lookup) returned results, the `member_device` response field will contain information about the member's device attributes.
     #   The type of this field is nilable +DeviceInfo+ (+object+).
+    # intermediate_session_token_expires_at::
+    #   (no documentation yet)
+    #   The type of this field is nilable +String+.
     def authenticate(
       organization_id:,
       email_address:,
@@ -601,6 +604,9 @@ module StytchB2B
       # member_device::
       #   If a valid `telemetry_id` was passed in the request and the [Fingerprint Lookup API](https://stytch.com/docs/fraud/api/fingerprint-lookup) returned results, the `member_device` response field will contain information about the member's device attributes.
       #   The type of this field is nilable +DeviceInfo+ (+object+).
+      # intermediate_session_token_expires_at::
+      #   (no documentation yet)
+      #   The type of this field is nilable +String+.
       def reset(
         password_reset_token:,
         password:,
@@ -775,6 +781,9 @@ module StytchB2B
       # member_device::
       #   If a valid `telemetry_id` was passed in the request and the [Fingerprint Lookup API](https://stytch.com/docs/fraud/api/fingerprint-lookup) returned results, the `member_device` response field will contain information about the member's device attributes.
       #   The type of this field is nilable +DeviceInfo+ (+object+).
+      # intermediate_session_token_expires_at::
+      #   (no documentation yet)
+      #   The type of this field is nilable +String+.
       def reset(
         organization_id:,
         password:,
@@ -916,6 +925,9 @@ module StytchB2B
       # member_device::
       #   If a valid `telemetry_id` was passed in the request and the [Fingerprint Lookup API](https://stytch.com/docs/fraud/api/fingerprint-lookup) returned results, the `member_device` response field will contain information about the member's device attributes.
       #   The type of this field is nilable +DeviceInfo+ (+object+).
+      # intermediate_session_token_expires_at::
+      #   (no documentation yet)
+      #   The type of this field is nilable +String+.
       def reset(
         email_address:,
         existing_password:,
@@ -998,6 +1010,9 @@ module StytchB2B
       # status_code::
       #   The HTTP status code of the response. Stytch follows standard HTTP response status code patterns, e.g. 2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX are server errors.
       #   The type of this field is +Integer+.
+      # intermediate_session_token_expires_at::
+      #   (no documentation yet)
+      #   The type of this field is nilable +String+.
       def authenticate(
         email_address:,
         password:
@@ -1140,6 +1155,9 @@ module StytchB2B
         # status_code::
         #   The HTTP status code of the response. Stytch follows standard HTTP response status code patterns, e.g. 2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX are server errors.
         #   The type of this field is +Integer+.
+        # intermediate_session_token_expires_at::
+        #   (no documentation yet)
+        #   The type of this field is nilable +String+.
         def reset(
           password_reset_token:,
           password:,

--- a/lib/stytch/b2b_sessions.rb
+++ b/lib/stytch/b2b_sessions.rb
@@ -318,6 +318,9 @@ module StytchB2B
     # member_device::
     #   If a valid `telemetry_id` was passed in the request and the [Fingerprint Lookup API](https://stytch.com/docs/fraud/api/fingerprint-lookup) returned results, the `member_device` response field will contain information about the member's device attributes.
     #   The type of this field is nilable +DeviceInfo+ (+object+).
+    # intermediate_session_token_expires_at::
+    #   (no documentation yet)
+    #   The type of this field is nilable +String+.
     def exchange(
       organization_id:,
       session_token: nil,

--- a/lib/stytch/b2b_sso.rb
+++ b/lib/stytch/b2b_sso.rb
@@ -239,6 +239,9 @@ module StytchB2B
     # member_device::
     #   If a valid `telemetry_id` was passed in the request and the [Fingerprint Lookup API](https://stytch.com/docs/fraud/api/fingerprint-lookup) returned results, the `member_device` response field will contain information about the member's device attributes.
     #   The type of this field is nilable +DeviceInfo+ (+object+).
+    # intermediate_session_token_expires_at::
+    #   (no documentation yet)
+    #   The type of this field is nilable +String+.
     def authenticate(
       sso_token:,
       pkce_code_verifier: nil,

--- a/lib/stytch/connected_apps.rb
+++ b/lib/stytch/connected_apps.rb
@@ -92,6 +92,9 @@ module Stytch
       # bypass_consent_for_offline_access::
       #   Valid for first party clients only. If true, the client does not need to request explicit user consent for the `offline_access` scope.
       #   The type of this field is nilable +Boolean+.
+      # id_token_template_content::
+      #   (no documentation yet)
+      #   The type of this field is nilable +String+.
       #
       # == Returns:
       # An object with the following fields:
@@ -115,7 +118,8 @@ module Stytch
         access_token_template_content: nil,
         post_logout_redirect_urls: nil,
         logo_url: nil,
-        bypass_consent_for_offline_access: nil
+        bypass_consent_for_offline_access: nil,
+        id_token_template_content: nil
       )
         headers = {}
         request = {}
@@ -129,6 +133,7 @@ module Stytch
         request[:post_logout_redirect_urls] = post_logout_redirect_urls unless post_logout_redirect_urls.nil?
         request[:logo_url] = logo_url unless logo_url.nil?
         request[:bypass_consent_for_offline_access] = bypass_consent_for_offline_access unless bypass_consent_for_offline_access.nil?
+        request[:id_token_template_content] = id_token_template_content unless id_token_template_content.nil?
 
         put_request("/v1/connected_apps/clients/#{client_id}", request, headers)
       end
@@ -232,6 +237,9 @@ module Stytch
       # bypass_consent_for_offline_access::
       #   Valid for first party clients only. If true, the client does not need to request explicit user consent for the `offline_access` scope.
       #   The type of this field is nilable +Boolean+.
+      # id_token_template_content::
+      #   (no documentation yet)
+      #   The type of this field is nilable +String+.
       #
       # == Returns:
       # An object with the following fields:
@@ -255,7 +263,8 @@ module Stytch
         access_token_template_content: nil,
         post_logout_redirect_urls: nil,
         logo_url: nil,
-        bypass_consent_for_offline_access: nil
+        bypass_consent_for_offline_access: nil,
+        id_token_template_content: nil
       )
         headers = {}
         request = {
@@ -271,6 +280,7 @@ module Stytch
         request[:post_logout_redirect_urls] = post_logout_redirect_urls unless post_logout_redirect_urls.nil?
         request[:logo_url] = logo_url unless logo_url.nil?
         request[:bypass_consent_for_offline_access] = bypass_consent_for_offline_access unless bypass_consent_for_offline_access.nil?
+        request[:id_token_template_content] = id_token_template_content unless id_token_template_content.nil?
 
         post_request('/v1/connected_apps/clients', request, headers)
       end

--- a/lib/stytch/version.rb
+++ b/lib/stytch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stytch
-  VERSION = '11.0.0'
+  VERSION = '11.1.0'
 end


### PR DESCRIPTION
Some minor updates:

* Adds new allowed locale values for SMS/ WhatsApp endpoints
* Adds the `intermediate_session_token_expires_at` parameter to responses that contain an intermediate session token
* Adds the optional `id_token_template_content` parameter to Connected Apps endpoints